### PR TITLE
Add posibility to use signing.properties for automatical package signing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,14 @@ android {
         exclude 'META-INF/DEPENDENCIES'
     }
 
+    signingConfigs {
+        release
+    }
+    buildTypes {
+        release {
+            signingConfig signingConfigs.release
+        }
+    }
     lintOptions {
         abortOnError false
     }
@@ -67,4 +75,29 @@ android {
         debug.setRoot('build-types/debug')
         release.setRoot('build-types/release')
     }
+}
+
+def Properties props = new Properties()
+def propFile = new File('signing.properties')
+
+if (propFile.canRead()){
+    props.load(new FileInputStream(propFile))
+
+    if (props !=null &&
+        props.containsKey('STORE_FILE')     &&
+        props.containsKey('STORE_PASSWORD') &&
+        props.containsKey('KEY_ALIAS')      &&
+        props.containsKey('KEY_PASSWORD'))
+    {
+        android.signingConfigs.release.storeFile = file(props['STORE_FILE'])
+        android.signingConfigs.release.storePassword = props['STORE_PASSWORD']
+        android.signingConfigs.release.keyAlias = props['KEY_ALIAS']
+        android.signingConfigs.release.keyPassword = props['KEY_PASSWORD']
+    } else {
+        println 'signing.properties found but some entries are missing'
+        android.buildTypes.release.signingConfig = null
+    }
+}else {
+    println 'signing.properties not found'
+    android.buildTypes.release.signingConfig = null
 }


### PR DESCRIPTION
Example *signing.properties* file:

```
STORE_FILE = /path/to/my/keyfile.keystore
STORE_PASSWORD = password
KEY_ALIAS = keyfilealias
KEY_PASSWORD = password2
```
