### PR TITLE
Separated changelogs and translators

### DIFF
--- a/res/values-de/changelog.xml
+++ b/res/values-de/changelog.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager.
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Nov 11, 2014&lt;/i>&lt;/font>&lt;br>&lt;br></string>
+    <string name="changelog_change_1">- Initial release&lt;br>&lt;br></string>
+</resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -130,10 +130,6 @@
     <string name="changegallerypath">Galleriepfad ändern</string>
     <string name="usedefaultgallerypath">Standard-Galleriepfad verwenden</string>
 
-    <!-- Changelog -->
-    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Nov 11, 2014&lt;/i>&lt;/font>&lt;br>&lt;br></string>
-    <string name="changelog_change_1">- Initial release&lt;br>&lt;br></string>
-
     <!-- New -->
     <!-- Array -->
 

--- a/res/values-es/changelog.xml
+++ b/res/values-es/changelog.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager.
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="changelog_version_1">&lt;Font color = \"# 524ef8\"&gt; &lt;b&gt; v1.0 &lt;/ font&gt; &lt;/ b&gt; &lt;i&gt; &lt;font color = \"# 5299f2\"&gt; &lt;br&gt; 11 de noviembre 2014 &lt;/ i&gt; &lt;/ font&gt; &lt;br&gt;</string>
+    <string name="changelog_change_1">- Versión inicial &lt;br&gt;</string>
+</resources>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -126,10 +126,6 @@
     <string name="changegallerypath">Cambiar la ruta de la galería</string>
     <string name="usedefaultgallerypath">Utilice la ruta por defecto de la galería</string>
 
-    <!-- Changelog -->
-    <string name="changelog_version_1">&lt;Font color = \"# 524ef8\"&gt; &lt;b&gt; v1.0 &lt;/ font&gt; &lt;/ b&gt; &lt;i&gt; &lt;font color = \"# 5299f2\"&gt; &lt;br&gt; 11 de noviembre 2014 &lt;/ i&gt; &lt;/ font&gt; &lt;br&gt;</string>
-    <string name="changelog_change_1">- Versión inicial &lt;br&gt;</string>
-
     <!-- New -->
     <!-- Array -->
 

--- a/res/values-eu/changelog.xml
+++ b/res/values-eu/changelog.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager.
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Aza 11, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_1">- Hasierako argitaratzea&lt;br>&lt;br></string>
+    <string name="changelog_version_2">&lt;font color="#524ef8">&lt;b>v1.1&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Abe 04, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_2">- Moztu/itsatsi konponduta&lt;br>
+                                      - root erabiltzailearentzako testu editorea konponduta&lt;br>
+                                      - Alemana, Frantsesa, Italiera, Errusiera eta Txinera gehituta&lt;br>
+                                      - Laster-markak nabigazio tiraderara gehituta&lt;br>
+                                      - Material elkarrizketak gehituta&lt;br>
+                                      - gehiago...&lt;br>&lt;br></string>
+    <string name="changelog_version_3">&lt;font color="#524ef8">&lt;b>v1.3&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Abe 13, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_3">- Gaztelania gehituta&lt;br>
+                                      - Hainbat konponketa Zip fitxategien bisorean&lt;br>
+                                      - apk eta jar fitxategiak ikus daitezke&lt;br>
+                                      - Hainbat konponketa testu editorean&lt;br>
+                                      - gehiago...&lt;br>&lt;br></string>
+    <string name="changelog_version_4">&lt;font color="#524ef8">&lt;b>v1.4&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Urt 17, 2015&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_4">    - Fitxa trukagarriak&lt;br>
+                                      - Erabat eguneratutako UIa&lt;br>
+                                      - Kopiatze/Itsaste/Erauzte/Konprimitze operazioak bizkortu&lt;br>
+                                      - Operazioen egoera jakinarazpenetan&lt;br>
+                                      - Konponketak Zip fitxategien bisorean eta testu editorean&lt;br>
+                                      - Sistemaren aplikazioak desinstalatzeko aukera&lt;br>
+                                      - Hobetutako fitxategien bilaketa&lt;br>
+                                      - Serbiera, euskara itzulpenak&lt;br>
+                                      - Atzera joan zerrenda burua ezgaitzeko aukera gehituta&lt;br>
+                                      - Aurre-ikuspegi biribilak ezgaitzeko aukera gehituta&lt;br>
+                                      - Artxiboen erauzketa eta konpresio karpeta hautatzeko aukera gehituta&lt;br>
+                                      - Bideak gogoratzeko aukera gehituta&lt;br>
+                                      - gehiago...&lt;br>&lt;br></string>
+</resources>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -132,36 +132,6 @@
     <string name="changegallerypath">Galeriaren bidea aldatu</string>
     <string name="usedefaultgallerypath">Irudi galeriaren bide lehenetsia erabili</string>
 
-    <!-- Changelog -->
-    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Aza 11, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_1">- Hasierako argitaratzea&lt;br>&lt;br></string>
-    <string name="changelog_version_2">&lt;font color="#524ef8">&lt;b>v1.1&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Abe 04, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_2">- Moztu/itsatsi konponduta&lt;br>
-                                      - root erabiltzailearentzako testu editorea konponduta&lt;br>
-                                      - Alemana, Frantsesa, Italiera, Errusiera eta Txinera gehituta&lt;br>
-                                      - Laster-markak nabigazio tiraderara gehituta&lt;br>
-                                      - Material elkarrizketak gehituta&lt;br>
-                                      - gehiago...&lt;br>&lt;br></string>
-    <string name="changelog_version_3">&lt;font color="#524ef8">&lt;b>v1.3&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Abe 13, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_3">- Gaztelania gehituta&lt;br>
-                                      - Hainbat konponketa Zip fitxategien bisorean&lt;br>
-                                      - apk eta jar fitxategiak ikus daitezke&lt;br>
-                                      - Hainbat konponketa testu editorean&lt;br>
-                                      - gehiago...&lt;br>&lt;br></string>
-    <string name="changelog_version_4">&lt;font color="#524ef8">&lt;b>v1.4&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Urt 17, 2015&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_4">    - Fitxa trukagarriak&lt;br>
-                                      - Erabat eguneratutako UIa&lt;br>
-                                      - Kopiatze/Itsaste/Erauzte/Konprimitze operazioak bizkortu&lt;br>
-                                      - Operazioen egoera jakinarazpenetan&lt;br>
-                                      - Konponketak Zip fitxategien bisorean eta testu editorean&lt;br>
-                                      - Sistemaren aplikazioak desinstalatzeko aukera&lt;br>
-                                      - Hobetutako fitxategien bilaketa&lt;br>
-                                      - Serbiera, euskara itzulpenak&lt;br>
-                                      - Atzera joan zerrenda burua ezgaitzeko aukera gehituta&lt;br>
-                                      - Aurre-ikuspegi biribilak ezgaitzeko aukera gehituta&lt;br>
-                                      - Artxiboen erauzketa eta konpresio karpeta hautatzeko aukera gehituta&lt;br>
-                                      - Bideak gogoratzeko aukera gehituta&lt;br>
-                                      - gehiago...&lt;br>&lt;br></string>
     <!-- New -->
     <!-- Array -->
 
@@ -303,16 +273,6 @@
     <string name="serbian_translation_title">Serbiera</string>
     <string name="turkish_translation_title">Turkiera</string>
     <string name="ukrainian_translation_title">Ukrainiera</string>
-    <string name="german_translation_summary">Patrick Mertens</string>
-    <string name="italian_translation_summary">Francesco Credidio</string>
-    <string name="french_translation_summary">Nicolas PIMENTEL, Primokorn, Renaud</string>
-    <string name="russian_translation_summary">Pablo Luchiano, Kim BeeJay</string>
-    <string name="spanish_translation_summary">Jose Miguel Sarasola</string>
-    <string name="basque_translation_summary">Aitor Beriain</string>
-    <string name="chinese_translation_summary">amtlib-dot-dll, Felix2yu</string>
-    <string name="serbian_translation_summary">Mladen Pejaković</string>
-    <string name="turkish_translation_summary">Hakan Güven</string>
-    <string name="ukrainian_translation_summary">Pablo Luchiano</string>
     <string name="zip_viewer">Zip bisorea</string>
     <string name="unin_system_apk">Sistemaren aplikazio bat da hau, ezabatzeak sistemaren ezegonkortasuna ekar lezake.\nJarraitu?</string>
     <string name="warning">Abisua</string>

--- a/res/values-fr/changelog.xml
+++ b/res/values-fr/changelog.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager.
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>11 Nov, 2014&lt;/i>&lt;/font>&lt;br>&lt;br></string>
+    <string name="changelog_change_1">- Première version&lt;br>&lt;br></string>
+    <string name="changelog_version_2">&lt;font color="#524ef8">&lt;b>v1.1&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>04 Dec, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_2">- Correction couper / coller&lt;br>
+                                      - Correction éditeur de texte pour le root&lt;br>
+                                      - Ajout des langages Allemand, Français, Italien, Russe et Chinois&lt;br>
+                                      - Ajout des signets pour le tiroir de navigation&lt;br>
+                                      - Ajout des boîtes de dialogue material&lt;br>
+                                      - plus...&lt;br>&lt;br></string>
+    <string name="changelog_version_3">&lt;font color="#524ef8">&lt;b>v1.3&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>13 Dec, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_3">- Ajout de l\'espagnol&lt;br>
+                                      - Diverses corrections de la visionneuse Zip&lt;br>
+                                      - Pouvoir visualiser les fichiers apk et jar&lt;br>
+                                      - Diverses corrections de l\'éditeur de texte&lt;br>
+                                      - plus...&lt;br>&lt;br></string>
+    <string name="changelog_version_4">&lt;font color="#524ef8">&lt;b>v1.4&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>17 Jan, 2015&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_4">- Onglets par balayage&lt;br>
+                                      - Interface utilisateur totalement réorganisé&lt;br>
+                                      - Opérations rapide pour copier / coller / extraire / compresser&lt;br>
+                                      - Progression des opérations dans les notifications&lt;br>
+                                      - Corrections pour le visionneur ZIP et l\'éditeur de texte&lt;br>
+                                      - Possibilité de désinstaller les applications système&lt;br>
+                                      - Amélioration de la recherche de fichiers&lt;br>
+                                      - Traductions Serbe et basque&lt;br>
+                                      - ajout d\'une préférence pour désactiver le retour en tête de liste&lt;br>
+                                      - Ajout d\'une préférence pour désactiver miniatures circulaires&lt;br>
+                                      - Ajout d\'une préférence pour choisir le répertoire d\'extraction et la compression de l\'archive&lt;br>
+                                      - Ajout d\'une préférence de se souvenir des chemins&lt;br>
+                                      - plus...&lt;br>&lt;br></string>
+</resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -132,36 +132,6 @@
     <string name="changegallerypath">Modifier le répertoire galerie</string>
     <string name="usedefaultgallerypath">Utiliser le répertoire par défaut de l\'image galerie</string>
 
-    <!-- Changelog -->
-    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>11 Nov, 2014&lt;/i>&lt;/font>&lt;br>&lt;br></string>
-    <string name="changelog_change_1">- Première version&lt;br>&lt;br></string>
-    <string name="changelog_version_2">&lt;font color="#524ef8">&lt;b>v1.1&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>04 Dec, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_2">- Correction couper / coller&lt;br>
-                                      - Correction éditeur de texte pour le root&lt;br>
-                                      - Ajout des langages Allemand, Français, Italien, Russe et Chinois&lt;br>
-                                      - Ajout des signets pour le tiroir de navigation&lt;br>
-                                      - Ajout des boîtes de dialogue material&lt;br>
-                                      - plus...&lt;br>&lt;br></string>
-    <string name="changelog_version_3">&lt;font color="#524ef8">&lt;b>v1.3&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>13 Dec, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_3">- Ajout de l\'espagnol&lt;br>
-                                      - Diverses corrections de la visionneuse Zip&lt;br>
-                                      - Pouvoir visualiser les fichiers apk et jar&lt;br>
-                                      - Diverses corrections de l\'éditeur de texte&lt;br>
-                                      - plus...&lt;br>&lt;br></string>
-    <string name="changelog_version_4">&lt;font color="#524ef8">&lt;b>v1.4&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>17 Jan, 2015&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_4">- Onglets par balayage&lt;br>
-                                      - Interface utilisateur totalement réorganisé&lt;br>
-                                      - Opérations rapide pour copier / coller / extraire / compresser&lt;br>
-                                      - Progression des opérations dans les notifications&lt;br>
-                                      - Corrections pour le visionneur ZIP et l\'éditeur de texte&lt;br>
-                                      - Possibilité de désinstaller les applications système&lt;br>
-                                      - Amélioration de la recherche de fichiers&lt;br>
-                                      - Traductions Serbe et basque&lt;br>
-                                      - ajout d\'une préférence pour désactiver le retour en tête de liste&lt;br>
-                                      - Ajout d\'une préférence pour désactiver miniatures circulaires&lt;br>
-                                      - Ajout d\'une préférence pour choisir le répertoire d\'extraction et la compression de l\'archive&lt;br>
-                                      - Ajout d\'une préférence de se souvenir des chemins&lt;br>
-                                      - plus...&lt;br>&lt;br></string>
     <!-- New -->
     <!-- Array -->
 
@@ -304,17 +274,6 @@
     <string name="turkish_translation_title">Turc</string>
     <string name="ukrainian_translation_title">Ukrainien</string>
     <string name="portuguese_translation_title">Portugais</string>
-    <string name="german_translation_summary">Patrick Mertens</string>
-    <string name="italian_translation_summary">Francesco Credidio</string>
-    <string name="french_translation_summary">Nicolas PIMENTEL, Primokorn, Rolland Renaud</string>
-    <string name="russian_translation_summary">Pablo Luchiano, Kim BeeJay</string>
-    <string name="spanish_translation_summary">Jose Miguel Sarasola</string>
-    <string name="basque_translation_summary">Aitor Beriain</string>
-    <string name="chinese_translation_summary">amtlib-dot-dll, Felix2yu</string>
-    <string name="serbian_translation_summary">Mladen Pejaković</string>
-    <string name="turkish_translation_summary">Hakan Güven</string>
-    <string name="ukrainian_translation_summary">Pablo Luchiano</string>
-    <string name="portuguese_translation_summary">Sérgio Marques</string>
     <string name="zip_viewer">Visionneur ZIP</string>
     <string name="unin_system_apk">Ceci est une application système, sa suppression pourrait conduire à une instabilité du système.\nPoursuivre ?</string>
     <string name="warning">Attention</string>

--- a/res/values-it/changelog.xml
+++ b/res/values-it/changelog.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager.
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Nov 11, 2014&lt;/i>&lt;/font>&lt;br>&lt;br></string>
+    <string name="changelog_change_1">- Initial release&lt;br>&lt;br></string>
+</resources>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -127,9 +127,6 @@
     <string name="fileexplorer">Gestore di files</string>
     <string name="changegallerypath">Cambia scorciatoia galleria</string>
     <string name="usedefaultgallerypath"> Utilizzare il percorso Immagini Galleria predefinito </string>
-    <!-- Changelog -->
-    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Nov 11, 2014&lt;/i>&lt;/font>&lt;br>&lt;br></string>
-    <string name="changelog_change_1">- Initial release&lt;br>&lt;br></string>
     <!-- New -->
     <!-- Array -->
     <!-- UI -->

--- a/res/values-pl/changelog.xml
+++ b/res/values-pl/changelog.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager. (translated by M. Kucharskov <M.Kucharskov@gmail.com>, P. Kowalczyk <p.d.kowalczyk@wp.pl>)
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Lis 11, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_1">- Pierwsze wydanie&lt;br>&lt;br></string>
+    <string name="changelog_version_2">&lt;font color="#524ef8">&lt;b>v1.1&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Gru 04, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_2">- Naprawiono kopiuj/wklej&lt;br>
+                                      - Naprawiono edytor tekstu dla root\'a&lt;br>
+                                      - Dodano języki niemiecki, francuski, włoski, rosyjski i chiński&lt;br>
+                                      - Dodano zakładki do panelu nawigacji&lt;br>
+                                      - Dodano okna dialogowe w stylu Material&lt;br>
+                                      - więcej...&lt;br>&lt;br></string>
+    <string name="changelog_version_3">&lt;font color="#524ef8">&lt;b>v1.3&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Gru 13, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_3">- Dodano hiszpański&lt;br>
+                                      - Różne poprawki przeglądarki archiwów&lt;br>
+                                      - Możliwość przeglądu plików apk i jar&lt;br>
+                                      - Różne poprawki edytora tekstu&lt;br>
+                                      - więcej...&lt;br>&lt;br></string>
+    <string name="changelog_version_4">&lt;font color="#524ef8">&lt;b>v1.4&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Sty 17, 2015&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_4">    - Przesuwalne karty&lt;br>
+                                      - W pełni przebudowany interfejs&lt;br>
+                                      - Szybsze operacje kopiowania/wklejania/wypakowywania/kompresji&lt;br>
+                                      - Postęp operacji w powiadomieniach&lt;br>
+                                      - Poprawki dla przeglądarki archiwów i edytora tekstu&lt;br>
+                                      - Możliwość odinstalowania aplikacji systemowej&lt;br>
+                                      - Usprawniono wyszukiwanie plików&lt;br>
+                                      - Tłumaczenia serbski, baskijski&lt;br>
+                                      - Dodano opcję włączenia nagłówka listy powrotu&lt;br>
+                                      - Dodano opcję wyłączenia okrągłych miniaturek&lt;br>
+                                      - Dodano opcję do wybrania folderu wypakowywania i pakowania&lt;br>
+                                      - Dodano opcję pamiętania ścieżek&lt;br>
+                                      - więcej...&lt;br>&lt;br></string>
+</resources>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -117,7 +117,7 @@
     <string name="refresh">Odśwież</string>
     <string name="copy">Kopiuj</string>
     <string name="rootmode">Przeglądanie z prawami root\'a</string>
-    <string name="rootmodesummary">Jedynie dla urządzeń z prawami root\'a. Zaznacz jeżeli jesteś tego pewien.</string> <!--XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->
+    <string name="rootmodesummary">Jedynie dla urządzeń z prawami root\'a. Zaznacz jeżeli jesteś tego pewien.</string>
     <string name="mountsystemsummary">Włącz jeżeli chcesz edytować pliki systemowe</string>
     <string name="mountsystem">Zapisz w folderach systemowych</string>
     <string name="rootfailure">Nie przyznano praw root\'a</string>
@@ -275,18 +275,6 @@
     <string name="ukrainian_translation_title">Ukraiński</string>
     <string name="portuguese_translation_title">Portugalski</string>
     <string name="polish_translation_title">Polski</string>
-    <string name="german_translation_summary">Patrick Mertens</string>
-    <string name="italian_translation_summary">Francesco Credidio</string>
-    <string name="french_translation_summary">Nicolas PIMENTEL, Primokorn, Renaud</string>
-    <string name="russian_translation_summary">Pablo Luchiano, Kim BeeJay</string>
-    <string name="spanish_translation_summary">Jose Miguel Sarasola</string>
-    <string name="basque_translation_summary">Aitor Beriain</string>
-    <string name="chinese_translation_summary">amtlib-dot-dll, Felix2yu</string>
-    <string name="serbian_translation_summary">Mladen Pejaković</string>
-    <string name="turkish_translation_summary">Hakan Güven</string>
-    <string name="ukrainian_translation_summary">Pablo Luchiano</string>
-    <string name="portuguese_translation_summary">Sérgio Marques</string>
-    <string name="polish_translation_summary">M. Kucharskov, P. Kowalczyk</string>
     <string name="zip_viewer">Przeglądarka archiwum</string>
     <string name="unin_system_apk">To jest aplikacja systemowa, usunięcie jej może prowadzić do niestabliności systemu.\nKontynuować?</string>
     <string name="warning">Ostrzeżenie</string>
@@ -308,5 +296,6 @@
     <string name="select_intent">Wybierz</string>
     <string name="md5copied">MD5 skopiowano do schowka</string>
     <string name="generating">Generowanie..</string>
+    <string name="tables">Tablice</string>
 </resources>
 

--- a/res/values-pt/changelog.xml
+++ b/res/values-pt/changelog.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager.
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>11 de nov. de 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_1">- Vesão inicial&lt;br>&lt;br></string>
+    <string name="changelog_version_2">&lt;font color="#524ef8">&lt;b>v1.1&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>4 de dez. de 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_2">- Corrigida opção cortar/colar&lt;br>
+                                      - Corrigido editor de texto para root&lt;br>
+                                      - Adicionadas traduções em alemão, francês, italiano, russo e chinês&lt;br>
+                                      - Adição de mracadores à gaveta de navegação&lt;br>
+                                      - Adição de diálogos material design&lt;br>
+                                      - mais...&lt;br>&lt;br></string>
+    <string name="changelog_version_3">&lt;font color="#524ef8">&lt;b>v1.3&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>13 de dez. de 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_3">- Adição de tradução em espanhol&lt;br>
+                                      - Correções ao visualizador zip&lt;br>
+                                      - Possibilidade de ver ficheiros apk e jar&lt;br>
+                                      - Correções ao editor de texto&lt;br>
+                                      - mais...&lt;br>&lt;br></string>
+    <string name="changelog_version_4">&lt;font color="#524ef8">&lt;b>v1.4&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>17 de jan. de 2015&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_4">- Separadores deslizáveis&lt;br>
+                                      - Melhorias na interface&lt;br>
+                                      - Melhoras nas operações copiar/colar/extrair/comprimir&lt;br>
+                                      - Progreso das operações nas notificações&lt;br>
+                                      - Correções ao visualizador zip e ao editor de texto&lt;br>
+                                      - Possibilidade de desinstalar aplicações do sistema&lt;br>
+                                      - Melhorias na procura de ficheiros&lt;br>
+                                      - Adicionada tradução em sérvio&lt;br>
+                                      - Adicionada preferência para desativar a opção Recuar na lista&lt;br>
+                                      - Adicionada preferência para desativar as miniaturas circulares&lt;br>
+                                      - Adicionada preferência para escolher o local de extração/compressão dos ficheiros&lt;br>
+                                      - Aicionada preferência para memorizar os caminhos&lt;br>
+                                      - mais...&lt;br>&lt;br></string>
+</resources>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -132,36 +132,6 @@
     <string name="changegallerypath">Mudar caminho da galeria</string>
     <string name="usedefaultgallerypath">Utilizar caminho pré-definido</string>
 
-    <!-- Changelog -->
-    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>11 de nov. de 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_1">- Vesão inicial&lt;br>&lt;br></string>
-    <string name="changelog_version_2">&lt;font color="#524ef8">&lt;b>v1.1&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>4 de dez. de 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_2">- Corrigida opção cortar/colar&lt;br>
-                                      - Corrigido editor de texto para root&lt;br>
-                                      - Adicionadas traduções em alemão, francês, italiano, russo e chinês&lt;br>
-                                      - Adição de mracadores à gaveta de navegação&lt;br>
-                                      - Adição de diálogos material design&lt;br>
-                                      - mais...&lt;br>&lt;br></string>
-    <string name="changelog_version_3">&lt;font color="#524ef8">&lt;b>v1.3&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>13 de dez. de 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_3">- Adição de tradução em espanhol&lt;br>
-                                      - Correções ao visualizador zip&lt;br>
-                                      - Possibilidade de ver ficheiros apk e jar&lt;br>
-                                      - Correções ao editor de texto&lt;br>
-                                      - mais...&lt;br>&lt;br></string>
-    <string name="changelog_version_4">&lt;font color="#524ef8">&lt;b>v1.4&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>17 de jan. de 2015&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_4">- Separadores deslizáveis&lt;br>
-                                      - Melhorias na interface&lt;br>
-                                      - Melhoras nas operações copiar/colar/extrair/comprimir&lt;br>
-                                      - Progreso das operações nas notificações&lt;br>
-                                      - Correções ao visualizador zip e ao editor de texto&lt;br>
-                                      - Possibilidade de desinstalar aplicações do sistema&lt;br>
-                                      - Melhorias na procura de ficheiros&lt;br>
-                                      - Adicionada tradução em sérvio&lt;br>
-                                      - Adicionada preferência para desativar a opção Recuar na lista&lt;br>
-                                      - Adicionada preferência para desativar as miniaturas circulares&lt;br>
-                                      - Adicionada preferência para escolher o local de extração/compressão dos ficheiros&lt;br>
-                                      - Aicionada preferência para memorizar os caminhos&lt;br>
-                                      - mais...&lt;br>&lt;br></string>
     <!-- New -->
     <!-- Array -->
 
@@ -304,17 +274,6 @@
     <string name="turkish_translation_title">Turco</string>
     <string name="ukrainian_translation_title">Ucraniano</string>
     <string name="portuguese_translation_title">Português</string>
-    <string name="german_translation_summary">Patrick Mertens</string>
-    <string name="italian_translation_summary">Francesco Credidio</string>
-    <string name="french_translation_summary">Nicolas PIMENTEL, Primokorn, Renaud</string>
-    <string name="russian_translation_summary">Pablo Luchiano, Kim BeeJay</string>
-    <string name="spanish_translation_summary">Jose Miguel Sarasola</string>
-    <string name="basque_translation_summary">Aitor Beriain</string>
-    <string name="chinese_translation_summary">amtlib-dot-dll, Felix2yu</string>
-    <string name="serbian_translation_summary">Mladen Pejaković</string>
-    <string name="turkish_translation_summary">Hakan Güven</string>
-    <string name="ukrainian_translation_summary">Pablo Luchiano</string>
-    <string name="portuguese_translation_summary">Sérgio Marques</string>
     <string name="zip_viewer">Visualizador zip</string>
     <string name="unin_system_apk">Esta aplicação é do sistema. Se a eliminar pode afetar a estabilidade do sistema.\nContinuar?</string>
     <string name="warning">Aviso</string>

--- a/res/values-ru/changelog.xml
+++ b/res/values-ru/changelog.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager.
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="changelog_version_1">&lt;font color="#524ef8"&gt;&lt;b&gt;v1.0&lt;/font&gt;&lt;/b&gt;&lt;i&gt;&lt;font color="#5299f2"&gt;&lt;br&gt;Nov 11, 2014&lt;/i&gt;&lt;/font&gt;&lt;br&gt;</string>
+    <string name="changelog_change_1">- Исходная версия&lt;br&gt;&lt;br&gt;</string>
+    <string name="changelog_version_2">&lt;font color=#524ef8&gt;&lt;b&gt;v1.1&lt;/font&gt;&lt;/b&gt;&lt;i&gt;&lt;font color=#5299f2&gt;&lt;br&gt;Dec 04, 2014&lt;/i&gt;&lt;/font&gt;&lt;br&gt;</string>
+    <string name="changelog_change_2">- Исправлено вырезать/вставить&lt;br&gt;
+                                      - Исправлен текстовый редактор для рут доступа&lt;br&gt;
+                                      - Добавлен Немецкий, Французский, Итальянский, Русский, Китайский языки&lt;br&gt;
+                                      - Добавлены закладки для навигации по секции&lt;br&gt;
+                                      - Добавлены материальные диалоги&lt;br&gt;
+                                      - прочие исправления...&lt;br&gt;&lt;br&gt;</string>
+    <string name="changelog_version_3">&lt;font color="#524ef8"&gt;&lt;b&gt;v1.3&lt;/font&gt;&lt;/b&gt;&lt;i&gt;&lt;font color="#5299f2"&gt;&lt;br&gt;Dec 13, 2014&lt;/i&gt;&lt;/font&gt;&lt;br&gt;</string>
+    <string name="changelog_change_3">- Добавлен Испанский&lt;br&gt;
+                                      - Различные исправления Zip Редактора&lt;br&gt;
+                                      - Теперь вы можете просматривать apk и jar файлы&lt;br&gt;
+                                      - Различные исправления в текстовом редакторе&lt;br&gt;
+                                      - прочие исправления...&lt;br&gt;&lt;br&gt;</string>
+</resources>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -128,23 +128,6 @@
     <string name="changegallerypath">Изменить путь к галерее</string>
     <string name="usedefaultgallerypath">Использ. путь к галерее по умолчанию</string>
 
-    <!-- Changelog -->
-    <string name="changelog_version_1">&lt;font color="#524ef8"&gt;&lt;b&gt;v1.0&lt;/font&gt;&lt;/b&gt;&lt;i&gt;&lt;font color="#5299f2"&gt;&lt;br&gt;Nov 11, 2014&lt;/i&gt;&lt;/font&gt;&lt;br&gt;</string>
-    <string name="changelog_change_1">- Исходная версия&lt;br&gt;&lt;br&gt;</string>
-    <string name="changelog_version_2">&lt;font color=#524ef8&gt;&lt;b&gt;v1.1&lt;/font&gt;&lt;/b&gt;&lt;i&gt;&lt;font color=#5299f2&gt;&lt;br&gt;Dec 04, 2014&lt;/i&gt;&lt;/font&gt;&lt;br&gt;</string>
-    <string name="changelog_change_2">- Исправлено вырезать/вставить&lt;br&gt;
-                                      - Исправлен текстовый редактор для рут доступа&lt;br&gt;
-                                      - Добавлен Немецкий, Французский, Итальянский, Русский, Китайский языки&lt;br&gt;
-                                      - Добавлены закладки для навигации по секции&lt;br&gt;
-                                      - Добавлены материальные диалоги&lt;br&gt;
-                                      - прочие исправления...&lt;br&gt;&lt;br&gt;</string>
-    <string name="changelog_version_3">&lt;font color="#524ef8"&gt;&lt;b&gt;v1.3&lt;/font&gt;&lt;/b&gt;&lt;i&gt;&lt;font color="#5299f2"&gt;&lt;br&gt;Dec 13, 2014&lt;/i&gt;&lt;/font&gt;&lt;br&gt;</string>
-    <string name="changelog_change_3">- Добавлен Испанский&lt;br&gt;
-                                      - Различные исправления Zip Редактора&lt;br&gt;
-                                      - Теперь вы можете просматривать apk и jar файлы&lt;br&gt;
-                                      - Различные исправления в текстовом редакторе&lt;br&gt;
-                                      - прочие исправления...&lt;br&gt;&lt;br&gt;</string>
-
     <!-- New -->
     <!-- Array -->
 
@@ -285,15 +268,6 @@
     <string name="chinese_translation_title">Китайский</string>
     <string name="serbian_translation_title">Сербский</string>
     <string name="turkish_translation_title">Турецкий</string>
-    <string name="german_translation_summary">Patrick Mertens</string>
-    <string name="italian_translation_summary">Francesco Credidio</string>
-    <string name="french_translation_summary">Nicolas PIMENTEL, Primokorn, Renaud</string>
-    <string name="russian_translation_summary">Pablo Luchiano, Kim BeeJay</string>
-    <string name="spanish_translation_summary">Jose Miguel Sarasola</string>
-    <string name="basque_translation_summary">Aitor Beriain</string>
-    <string name="chinese_translation_summary">amtlib-dot-dll, Felix2yu</string>
-    <string name="serbian_translation_summary">Mladen Pejaković</string>
-    <string name="turkish_translation_summary">Hakan Güven</string>
     <string name="zip_viewer">Просмотр ZIP</string>
     <string name="unin_system_apk">Это системное приложение, удаление может привести к нестабильности системы.
 Продолжить?</string>

--- a/res/values-sr/changelog.xml
+++ b/res/values-sr/changelog.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager.
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>в1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>11. нов, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_1">- Почетно издање&lt;br>&lt;br></string>
+    <string name="changelog_version_2">&lt;font color="#524ef8">&lt;b>в1.1&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>04. дец, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_2">- Поправљено исеци/налепи&lt;br>
+                                      - Поправљен уређивач текста за корен&lt;br>
+                                      - Додати немачки, француски, италијански, руски и кинески језици&lt;br>
+                                      - Додати обележивачи у навигациону фиоку&lt;br>
+                                      - Додати материјал дијалози&lt;br>
+                                      - још тога...&lt;br>&lt;br></string>
+    <string name="changelog_version_3">&lt;font color="#524ef8">&lt;b>в1.3&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>13. дец, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_3">- Додат шпански&lt;br>
+                                      - Разне исправке зип прегледача&lt;br>
+                                      - Приказ апк и јар фајлова&lt;br>
+                                      - Разне исправке уређивача текста&lt;br>
+                                      - још тога...&lt;br>&lt;br></string>
+    <string name="changelog_version_4">&lt;font color="#524ef8">&lt;b>в1.4&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>17. јан, 2015&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_4">    - Превлачење језичака&lt;br>
+                                      - Преуређено сучеље&lt;br>
+                                      - Убрзане радње копирања/лепљења/распакивања/компресовања&lt;br>
+                                      - Напредак радњи у обавештењима&lt;br>
+                                      - Исправке зип прегледача и уређивача текста&lt;br>
+                                      - Могућност уклањања системских апликација&lt;br>
+                                      - Побољшана претрага фајлова&lt;br>
+                                      - Преводи на српски и баскијски&lt;br>
+                                      - Могућност да се искључи заглавље списка за назад&lt;br>
+                                      - Могућност да се искључе кружне сличице&lt;br>
+                                      - Могућност да се одреди фасцикла за распакивање и компресовање&lt;br>
+                                      - Могућност да се запамте путање&lt;br>
+                                      - још тога...&lt;br>&lt;br></string>
+</resources>

--- a/res/values-sr/strings.xml
+++ b/res/values-sr/strings.xml
@@ -132,36 +132,6 @@
     <string name="changegallerypath">Промени путању Галерије</string>
     <string name="usedefaultgallerypath">Користи подразумевану путању</string>
 
-    <!-- Changelog -->
-    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>в1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>11. нов, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_1">- Почетно издање&lt;br>&lt;br></string>
-    <string name="changelog_version_2">&lt;font color="#524ef8">&lt;b>в1.1&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>04. дец, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_2">- Поправљено исеци/налепи&lt;br>
-                                      - Поправљен уређивач текста за корен&lt;br>
-                                      - Додати немачки, француски, италијански, руски и кинески језици&lt;br>
-                                      - Додати обележивачи у навигациону фиоку&lt;br>
-                                      - Додати материјал дијалози&lt;br>
-                                      - још тога...&lt;br>&lt;br></string>
-    <string name="changelog_version_3">&lt;font color="#524ef8">&lt;b>в1.3&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>13. дец, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_3">- Додат шпански&lt;br>
-                                      - Разне исправке зип прегледача&lt;br>
-                                      - Приказ апк и јар фајлова&lt;br>
-                                      - Разне исправке уређивача текста&lt;br>
-                                      - још тога...&lt;br>&lt;br></string>
-    <string name="changelog_version_4">&lt;font color="#524ef8">&lt;b>в1.4&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>17. јан, 2015&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_4">    - Превлачење језичака&lt;br>
-                                      - Преуређено сучеље&lt;br>
-                                      - Убрзане радње копирања/лепљења/распакивања/компресовања&lt;br>
-                                      - Напредак радњи у обавештењима&lt;br>
-                                      - Исправке зип прегледача и уређивача текста&lt;br>
-                                      - Могућност уклањања системских апликација&lt;br>
-                                      - Побољшана претрага фајлова&lt;br>
-                                      - Преводи на српски и баскијски&lt;br>
-                                      - Могућност да се искључи заглавље списка за назад&lt;br>
-                                      - Могућност да се искључе кружне сличице&lt;br>
-                                      - Могућност да се одреди фасцикла за распакивање и компресовање&lt;br>
-                                      - Могућност да се запамте путање&lt;br>
-                                      - још тога...&lt;br>&lt;br></string>
     <!-- New -->
     <!-- Array -->
 
@@ -303,16 +273,6 @@
     <string name="serbian_translation_title">Српски</string>
     <string name="turkish_translation_title">Турски</string>
     <string name="ukrainian_translation_title">Украјински</string>
-    <string name="german_translation_summary">Patrick Mertens</string>
-    <string name="italian_translation_summary">Francesco Credidio</string>
-    <string name="french_translation_summary">Nicolas PIMENTEL, Primokorn, Renaud</string>
-    <string name="russian_translation_summary">Pablo Luchiano, Kim BeeJay</string>
-    <string name="spanish_translation_summary">Jose Miguel Sarasola</string>
-    <string name="basque_translation_summary">Aitor Beriain</string>
-    <string name="chinese_translation_summary">amtlib-dot-dll, Felix2yu</string>
-    <string name="serbian_translation_summary">Младен Пејаковић</string>
-    <string name="turkish_translation_summary">Hakan Güven</string>
-    <string name="ukrainian_translation_summary">Pablo Luchiano</string>
     <string name="zip_viewer">Зип прегледач</string>
     <string name="unin_system_apk">Ово је системска апликација, уклањање може да доведе до нестабилности система.\nДа наставим?</string>
     <string name="warning">Упозорење</string>

--- a/res/values-tr/changelog.xml
+++ b/res/values-tr/changelog.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager.
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="changelog_change_1">- ilk sürüm&lt;br>&lt;br></string>
+    <string name="changelog_change_2">- Sabit kesme/paste&lt;br> - Root için sabit bir metin editörü&lt;br> - Almanca, Fransızca, İtalyanca, Rusça ve Çince dilleri eklendi&lt;br> - Navigasyon çekmece imleri eklendi&lt;br> - Meteryal diyalogları eklendi&lt;br> - more...&lt;br>&lt;br></string>
+    <string name="changelog_change_3">- İspanyolca eklendi&lt;br> - Çeşitli sıkıştırma görüntüleyici düzeltmeleri&lt;br> - Apk ve jar dosyalarını görüntüleyebilme&lt;br> - Çeşitli metin editörü düzeltmeleri&lt;br> - Dahası...&lt;br>&lt;br></string>
+    <string name="changelog_version_1">&lt;font color=#524ef8>&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color=#5299f2>&lt;br>Nov 11, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_version_2">&lt;font color=#524ef8>&lt;b>v1.1&lt;/font>&lt;/b>&lt;i>&lt;font color=#5299f2>&lt;br>Dec 04, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_version_3">&lt;font color=#524ef8>&lt;b>v1.3&lt;/font>&lt;/b>&lt;i>&lt;font color=#5299f2>&lt;br>Dec 13, 2014&lt;/i>&lt;/font>&lt;br></string>
+</resources>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -31,12 +31,6 @@
     <string name="card">Kart</string>
     <string name="changegallerypath">Galeri yolunu değiştir</string>
     <string name="changelog">Değişiklik</string>
-    <string name="changelog_change_1">- ilk sürüm&lt;br>&lt;br></string>
-    <string name="changelog_change_2">- Sabit kesme/paste&lt;br> - Root için sabit bir metin editörü&lt;br> - Almanca, Fransızca, İtalyanca, Rusça ve Çince dilleri eklendi&lt;br> - Navigasyon çekmece imleri eklendi&lt;br> - Meteryal diyalogları eklendi&lt;br> - more...&lt;br>&lt;br></string>
-    <string name="changelog_change_3">- İspanyolca eklendi&lt;br> - Çeşitli sıkıştırma görüntüleyici düzeltmeleri&lt;br> - Apk ve jar dosyalarını görüntüleyebilme&lt;br> - Çeşitli metin editörü düzeltmeleri&lt;br> - Dahası...&lt;br>&lt;br></string>
-    <string name="changelog_version_1">&lt;font color=#524ef8>&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color=#5299f2>&lt;br>Nov 11, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_version_2">&lt;font color=#524ef8>&lt;b>v1.1&lt;/font>&lt;/b>&lt;i>&lt;font color=#5299f2>&lt;br>Dec 04, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_version_3">&lt;font color=#524ef8>&lt;b>v1.3&lt;/font>&lt;/b>&lt;i>&lt;font color=#5299f2>&lt;br>Dec 13, 2014&lt;/i>&lt;/font>&lt;br></string>
     <string name="chooseUI">Ürün seç</string>
     <string name="close">Kapat</string>
     <string name="colorize">Simgeleri renklendirme</string>

--- a/res/values-uk/changelog.xml
+++ b/res/values-uk/changelog.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager.
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="changelog_version_1">&lt;font color="#524ef8"&gt;&lt;b&gt;v1.0&lt;/font&gt;&lt;/b&gt;&lt;i&gt;&lt;font color="#5299f2"&gt;&lt;br&gt;Nov 11, 2014&lt;/i&gt;&lt;/font&gt;&lt;br&gt;</string>
+    <string name="changelog_change_1">- Вихідна версія&lt;br&gt;&lt;br&gt;</string>
+    <string name="changelog_version_2">&lt;font color=#524ef8&gt;&lt;b&gt;v1.1&lt;/font&gt;&lt;/b&gt;&lt;i&gt;&lt;font color=#5299f2&gt;&lt;br&gt;Dec 04, 2014&lt;/i&gt;&lt;/font&gt;&lt;br&gt;</string>
+    <string name="changelog_change_2">- Виправлено вирізати/вставити&lt;br&gt;
+                                      - Виправлений текстовий редактор для рут доступу&lt;br&gt;
+                                      - Додано Німецька, Французька, Італійська, Російська, Китайська мови&lt;br&gt;
+                                      - Додані закладки для навігації по секції&lt;br&gt;
+                                      - Доданий матеріал діалогів&lt;br&gt;
+                                      - інші виправлення.&lt;br&gt;&lt;br&gt;</string>
+    <string name="changelog_version_3">&lt;font color="#524ef8"&gt;&lt;b&gt;v1.3&lt;/font&gt;&lt;/b&gt;&lt;i&gt;&lt;font color="#5299f2"&gt;&lt;br&gt;Dec 13, 2014&lt;/i&gt;&lt;/font&gt;&lt;br&gt;</string>
+    <string name="changelog_change_3">- Додано Іспанська мова&lt;br&gt;&#13;
+                                      - Різні Zip Редактора виправлення&lt;br&gt;&#13;
+                                      - Тепер ви можете переглядати apk і jar файли&lt;br&gt;&#13;
+                                      - Різні виправлення в текстовому редакторі&lt;br&gt;&#13;
+                                      - інші виправлення...&lt;br&gt;&lt;br&gt;</string>
+</resources>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -130,23 +130,6 @@
     <string name="changegallerypath">Змінити шлях до галереї</string>
     <string name="usedefaultgallerypath">Використ. шлях до галереї за замовчуванням</string>
 
-    <!-- Changelog -->
-    <string name="changelog_version_1">&lt;font color="#524ef8"&gt;&lt;b&gt;v1.0&lt;/font&gt;&lt;/b&gt;&lt;i&gt;&lt;font color="#5299f2"&gt;&lt;br&gt;Nov 11, 2014&lt;/i&gt;&lt;/font&gt;&lt;br&gt;</string>
-    <string name="changelog_change_1">- Вихідна версія&lt;br&gt;&lt;br&gt;</string>
-    <string name="changelog_version_2">&lt;font color=#524ef8&gt;&lt;b&gt;v1.1&lt;/font&gt;&lt;/b&gt;&lt;i&gt;&lt;font color=#5299f2&gt;&lt;br&gt;Dec 04, 2014&lt;/i&gt;&lt;/font&gt;&lt;br&gt;</string>
-    <string name="changelog_change_2">- Виправлено вирізати/вставити&lt;br&gt;
-                                      - Виправлений текстовий редактор для рут доступу&lt;br&gt;
-                                      - Додано Німецька, Французька, Італійська, Російська, Китайська мови&lt;br&gt;
-                                      - Додані закладки для навігації по секції&lt;br&gt;
-                                      - Доданий матеріал діалогів&lt;br&gt;
-                                      - інші виправлення.&lt;br&gt;&lt;br&gt;</string>
-    <string name="changelog_version_3">&lt;font color="#524ef8"&gt;&lt;b&gt;v1.3&lt;/font&gt;&lt;/b&gt;&lt;i&gt;&lt;font color="#5299f2"&gt;&lt;br&gt;Dec 13, 2014&lt;/i&gt;&lt;/font&gt;&lt;br&gt;</string>
-    <string name="changelog_change_3">- Додано Іспанська мова&lt;br&gt;&#13;
-                                      - Різні Zip Редактора виправлення&lt;br&gt;&#13;
-                                      - Тепер ви можете переглядати apk і jar файли&lt;br&gt;&#13;
-                                      - Різні виправлення в текстовому редакторі&lt;br&gt;&#13;
-                                      - інші виправлення...&lt;br&gt;&lt;br&gt;</string>
-
     <!-- New -->
     <!-- Array -->
 
@@ -287,15 +270,6 @@
     <string name="chinese_translation_title">Китайська</string>
     <string name="serbian_translation_title">Сербська</string>
     <string name="turkish_translation_title">Турецька</string>
-    <string name="german_translation_summary">Patrick Mertens</string>
-    <string name="italian_translation_summary">Francesco Credidio</string>
-    <string name="french_translation_summary">Nicolas PIMENTEL, Primokorn, Renaud</string>
-    <string name="russian_translation_summary">Pablo Luchiano, Kim BeeJay</string>
-    <string name="spanish_translation_summary">Jose Miguel Sarasola</string>
-    <string name="basque_translation_summary">Aitor Beriain</string>
-    <string name="chinese_translation_summary">amtlib-dot-dll, Felix2yu</string>
-    <string name="serbian_translation_summary">Mladen Pejaković</string>
-    <string name="turkish_translation_summary">Hakan Güven</string>
     <string name="zip_viewer">Перегляд ZIP</string>
     <string name="unin_system_apk">Це системний додаток, його видалення може спричинити нестабільність системи.
 Ви хочете продовжити?</string>

--- a/res/values/changelog.xml
+++ b/res/values/changelog.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager.
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Nov 11, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_1">- Initial release&lt;br>&lt;br></string>
+    <string name="changelog_version_2">&lt;font color="#524ef8">&lt;b>v1.1&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Dec 04, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_2">- Fixed cut/paste&lt;br>
+                                      - Fixed text editor for root&lt;br>
+                                      - Added German, French, Italian, Russian and Chinese languages&lt;br>
+                                      - Added bookmarks to navigation drawer&lt;br>
+                                      - Added material dialogs&lt;br>
+                                      - more...&lt;br>&lt;br></string>
+    <string name="changelog_version_3">&lt;font color="#524ef8">&lt;b>v1.3&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Dec 13, 2014&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_3">- Added Spanish&lt;br>
+                                      - Various Zip Viewer fixes&lt;br>
+                                      - Can view apk and jar files&lt;br>
+                                      - Various text editor fixes&lt;br>
+                                      - more...&lt;br>&lt;br></string>
+    <string name="changelog_version_4">&lt;font color="#524ef8">&lt;b>v1.4&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Jan 17, 2015&lt;/i>&lt;/font>&lt;br></string>
+    <string name="changelog_change_4">    - Swipable tabs&lt;br>
+                                      - Fully revamped UI&lt;br>
+                                      - Speedy copy/paste/extract/compress operations&lt;br>
+                                      - Progress of operations in notifications&lt;br>
+                                      - Fixes for zip viewer and text editor&lt;br>
+                                      - Ability to uninstall system apps&lt;br>
+                                      - Improved searching of files&lt;br>
+                                      - Serbian,basque translations&lt;br>
+                                      - Added preference to disable go back list header&lt;br>
+                                      - Added preference to disable circular thumbnails&lt;br>
+                                      - Added preference to choose archive extract and compress directory&lt;br>
+                                      - Added preference to remember paths&lt;br>
+                                      - more...&lt;br>&lt;br></string>
+</resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -132,36 +132,6 @@
     <string name="changegallerypath">Change Gallery Path</string>
     <string name="usedefaultgallerypath">Use Default Image Gallery Path</string>
 
-    <!-- Changelog -->
-    <string name="changelog_version_1">&lt;font color="#524ef8">&lt;b>v1.0&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Nov 11, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_1">- Initial release&lt;br>&lt;br></string>
-    <string name="changelog_version_2">&lt;font color="#524ef8">&lt;b>v1.1&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Dec 04, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_2">- Fixed cut/paste&lt;br>
-                                      - Fixed text editor for root&lt;br>
-                                      - Added German, French, Italian, Russian and Chinese languages&lt;br>
-                                      - Added bookmarks to navigation drawer&lt;br>
-                                      - Added material dialogs&lt;br>
-                                      - more...&lt;br>&lt;br></string>
-    <string name="changelog_version_3">&lt;font color="#524ef8">&lt;b>v1.3&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Dec 13, 2014&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_3">- Added Spanish&lt;br>
-                                      - Various Zip Viewer fixes&lt;br>
-                                      - Can view apk and jar files&lt;br>
-                                      - Various text editor fixes&lt;br>
-                                      - more...&lt;br>&lt;br></string>
-    <string name="changelog_version_4">&lt;font color="#524ef8">&lt;b>v1.4&lt;/font>&lt;/b>&lt;i>&lt;font color="#5299f2">&lt;br>Jan 17, 2015&lt;/i>&lt;/font>&lt;br></string>
-    <string name="changelog_change_4">    - Swipable tabs&lt;br>
-                                      - Fully revamped UI&lt;br>
-                                      - Speedy copy/paste/extract/compress operations&lt;br>
-                                      - Progress of operations in notifications&lt;br>
-                                      - Fixes for zip viewer and text editor&lt;br>
-                                      - Ability to uninstall system apps&lt;br>
-                                      - Improved searching of files&lt;br>
-                                      - Serbian,basque translations&lt;br>
-                                      - Added preference to disable go back list header&lt;br>
-                                      - Added preference to disable circular thumbnails&lt;br>
-                                      - Added preference to choose archive extract and compress directory&lt;br>
-                                      - Added preference to remember paths&lt;br>
-                                      - more...&lt;br>&lt;br></string>
     <!-- New -->
     <!-- Array -->
 
@@ -304,17 +274,6 @@
     <string name="turkish_translation_title">Turkish</string>
     <string name="ukrainian_translation_title">Ukrainian</string>
     <string name="portuguese_translation_title">Portuguese</string>
-    <string name="german_translation_summary">Patrick Mertens</string>
-    <string name="italian_translation_summary">Francesco Credidio</string>
-    <string name="french_translation_summary">Nicolas PIMENTEL, Primokorn, Renaud</string>
-    <string name="russian_translation_summary">Pablo Luchiano, Kim BeeJay</string>
-    <string name="spanish_translation_summary">Jose Miguel Sarasola</string>
-    <string name="basque_translation_summary">Aitor Beriain</string>
-    <string name="chinese_translation_summary">amtlib-dot-dll, Felix2yu</string>
-    <string name="serbian_translation_summary">Mladen Pejaković</string>
-    <string name="turkish_translation_summary">Hakan Güven</string>
-    <string name="ukrainian_translation_summary">Pablo Luchiano</string>
-    <string name="portuguese_translation_summary">Sérgio Marques</string>
     <string name="zip_viewer">Zip Viewer</string>
     <string name="unin_system_apk">This is a system app, deleting it might lead to system un-stability.\nProceed?</string>
     <string name="warning">Warning</string>

--- a/res/values/translators.xml
+++ b/res/values/translators.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2014 Arpit Khurana <arpitkh96@gmail.com>, Vishal Nehra <vishalmeham2@gmail.com>
+
+    This file is part of Amaze File Manager.
+
+    Amaze File Manager is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    -->
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="MissingTranslation">
+    <string name="german_translation_summary">Patrick Mertens</string>
+    <string name="italian_translation_summary">Francesco Credidio</string>
+    <string name="french_translation_summary">Nicolas PIMENTEL, Primokorn, Renaud</string>
+    <string name="russian_translation_summary">Pablo Luchiano, Kim BeeJay</string>
+    <string name="spanish_translation_summary">Jose Miguel Sarasola</string>
+    <string name="basque_translation_summary">Aitor Beriain</string>
+    <string name="chinese_translation_summary">amtlib-dot-dll, Felix2yu</string>
+    <string name="serbian_translation_summary">Mladen Pejaković</string>
+    <string name="turkish_translation_summary">Hakan Güven</string>
+    <string name="ukrainian_translation_summary">Pablo Luchiano</string>
+    <string name="portuguese_translation_summary">Sérgio Marques</string>
+    <string name="polish_translation_summary">M. Kucharskov, P. Kowalczyk</string>
+</resources>


### PR DESCRIPTION
- Changelog.xml - separated changelogs in other langs. If translator
didn't translate new changelog Android should use english strings
- Trasnaltors.xml - separated names of users which translate app. Only in english folder - the same names in all langs in app. (easy to fix mistake in name)
- values-pl - minor bugfix and added last "Table(s)" string

I can only do that. But i dunno how to implement using changelog.xml and
translators.xml in app.

Regards!
Kucharskov ;)