### PR TITLE
Force chooser on open-with, allow default handler for archives

### DIFF
--- a/src/com/amaze/filemanager/activities/TextReader.java
+++ b/src/com/amaze/filemanager/activities/TextReader.java
@@ -306,7 +306,7 @@ public class TextReader extends ActionBarActivity implements TextWatcher {
             utils.showProps(mFile, c, theme1);
             return true;
         } else if (item.getItemId() == R.id.openwith) {
-            utils.openunknown(mFile, c);
+            utils.openunknown(mFile, c, false);
         }
         return super.onOptionsItemSelected(item);
     }

--- a/src/com/amaze/filemanager/fragments/Main.java
+++ b/src/com/amaze/filemanager/fragments/Main.java
@@ -1026,10 +1026,10 @@ public class Main extends android.support.v4.app.Fragment {
                     return true;
                 case R.id.openwith:
                     if (results)utils.openunknown(new File(slist.get(
-                            (plist.get(0))).getDesc()), getActivity());
+                            (plist.get(0))).getDesc()), getActivity(), true);
                     else
                         utils.openunknown(new File(list.get(
-                                (plist.get(0))).getDesc()), getActivity());
+                                (plist.get(0))).getDesc()), getActivity(), true);
 
                     return true;
                 case R.id.permissions:

--- a/src/com/amaze/filemanager/utils/Futils.java
+++ b/src/com/amaze/filemanager/utils/Futils.java
@@ -26,6 +26,8 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.content.res.Resources;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
@@ -151,6 +153,16 @@ public class Futils {
 
     }
 
+    private boolean isSelfDefault(File f, Context c){
+        Intent intent = new Intent();
+        intent.setAction(android.content.Intent.ACTION_VIEW);
+        intent.setDataAndType(Uri.fromFile(f), MimeTypes.getMimeType(f));
+        String s="";
+        ResolveInfo rii = c.getPackageManager().resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY);
+        if (rii !=  null && rii.activityInfo != null) s = rii.activityInfo.packageName;
+        if (s=="com.amaze.filemanager" || rii==null) return true;
+        else return false;
+    }
 
     public void openunknown(File f, Context c, boolean forcechooser) {
         Intent intent = new Intent();
@@ -494,16 +506,16 @@ public class Futils {
     }
 
     public void openFile(final File f, final MainActivity m) {
-         if (f.getName().toLowerCase().endsWith(".zip") || f.getName().toLowerCase().endsWith(".jar") || f.getName().toLowerCase().endsWith(".rar")|| f.getName().toLowerCase().endsWith(".tar")|| f.getName().toLowerCase().endsWith(".tar.gz")) {
+        boolean defaultHandler = isSelfDefault(f, m);
+        if (defaultHandler && f.getName().toLowerCase().endsWith(".zip") || f.getName().toLowerCase().endsWith(".jar") || f.getName().toLowerCase().endsWith(".rar")|| f.getName().toLowerCase().endsWith(".tar")|| f.getName().toLowerCase().endsWith(".tar.gz")) {
             showArchiveDialog(f, m);
-
-        }else if(f.getName().toLowerCase().endsWith(".apk")){
+        } else if(defaultHandler && f.getName().toLowerCase().endsWith(".apk")) {
             showPackageDialog(f,m);
-        } else if (f.getName().toLowerCase().endsWith(".db")) {
+        } else if (defaultHandler && f.getName().toLowerCase().endsWith(".db")) {
             Intent intent = new Intent(m, DbViewer.class);
             intent.putExtra("path", f.getPath());
             m.startActivity(intent);
-        }else {
+        } else {
             try {
                 openunknown(f, m, false);
             } catch (Exception e) {

--- a/src/com/amaze/filemanager/utils/Futils.java
+++ b/src/com/amaze/filemanager/utils/Futils.java
@@ -152,15 +152,18 @@ public class Futils {
     }
 
 
-    public void openunknown(File f, Context c) {
+    public void openunknown(File f, Context c, boolean forcechooser) {
         Intent intent = new Intent();
         intent.setAction(android.content.Intent.ACTION_VIEW);
 
         String type = MimeTypes.getMimeType(f);
         if(type!=null && type.trim().length()!=0 && !type.equals("*/*"))
         {intent.setDataAndType(Uri.fromFile(f), type);
+        Intent startintent;
+        if (forcechooser) startintent=Intent.createChooser(intent, c.getResources().getString(R.string.openwith));
+        else startintent=intent;
         try {
-            c.startActivity(intent);
+            c.startActivity(startintent);
         } catch (ActivityNotFoundException e) {
             e.printStackTrace();
         Toast.makeText(c,R.string.noappfound,Toast.LENGTH_SHORT).show();
@@ -502,7 +505,7 @@ public class Futils {
             m.startActivity(intent);
         }else {
             try {
-                openunknown(f, m);
+                openunknown(f, m, false);
             } catch (Exception e) {
                 Toast.makeText(m, getString(m, R.string.noappfound),Toast.LENGTH_LONG).show();
                 openWith(f, m);
@@ -514,7 +517,7 @@ public void showPackageDialog(final File f,final MainActivity m){
     mat.title(R.string.packageinstaller).content(R.string.pitext).positiveText(R.string.install).negativeText(R.string.view).neutralText(R.string.cancel).callback(new MaterialDialog.Callback() {
         @Override
         public void onPositive(MaterialDialog materialDialog) {
-            openunknown(f,m);
+            openunknown(f,m,false);
         }
 
         @Override


### PR DESCRIPTION
Long-click selection --> menu --> open with, should force chooser for file handler rather than opening the default handler, which will be automatically called on short-click.