### PR TITLE
Updated Greek translation

### DIFF
--- a/src/main/res/values-el/strings.xml
+++ b/src/main/res/values-el/strings.xml
@@ -334,5 +334,25 @@
     <string name="needsaccess">Απαιτείται πρόσβαση εγγραφής</string>
     <string name="needsaccesssummary">Παρακαλώ, επιλέξτε το φάκελο root του\t</string>
     <string name="needsaccesssummary1">\tγια να δώσετε άδεια πρόσβασης εγγραφής</string>
-
+    <string name="smb_con">Συνδέσεις SMB</string>
+    <string name="smb_server">Διακομιστής: Διευθ. IP ή Διευθ. IP/ΚοινόςΦάκελος</string>
+    <string name="username">Χρήστης</string>
+    <string name="password">Κωδικός</string>
+    <string name="anonymous">Ανώνυμος</string>
+    <string name="bluetooth">Bluetooth</string>
+    <string name="extstorage">Κάρτα μνήμης</string>
+    <string name="folders">Φάκελοι</string>
+    <string name="videos">Βίντεο</string>
+    <string name="apks">Apks</string>
+    <string name="documents">Έγγραφα</string>
+    <string name="images">Εικόνες</string>
+    <string name="clear">Καθαρισμός</string>
+    <string name="md5">md5: </string>
+    <string name="md5_2">Αντιγραφή md5</string>
+    <string name="total">Σύνολο: </string>
+    <string name="calculating"> υπολογισμός </string>
+    <string name="sort">Ταξινόμηση</string>
+    <string name="ascending">Αύξουσα</string>
+    <string name="descending">Φθήνουσα</string>
+    <string name="defualt">Εξ' ορισμού</string>
 </resources>


### PR DESCRIPTION
Though I found the "videos, apks, documents, images" strings of the sliding menu, there isn't the "Audio" string. Anyway its translation is "Ήχος". Please add it if you can.