### PR TITLE
Toast text fix.

### DIFF
--- a/src/main/java/com/amaze/filemanager/services/asynctasks/GenerateMD5Task.java
+++ b/src/main/java/com/amaze/filemanager/services/asynctasks/GenerateMD5Task.java
@@ -151,7 +151,7 @@ public class GenerateMD5Task extends AsyncTask<String, String, String> {
                     public void onClick(View v) {
                         try {
                             new Futils().copyToClipboard(c, md5);
-                            Toast.makeText(c, c.getResources().getString(R.string.pathcopied), Toast.LENGTH_SHORT).show();
+                            Toast.makeText(c, c.getResources().getString(R.string.md5copied), Toast.LENGTH_SHORT).show();
                         } catch (Exception e) {
                             e.printStackTrace();
                         }


### PR DESCRIPTION
Was showing 'Path copied to clipboard', instead of 'MD5 copied to clipboard'