### PR TITLE
Notification for FTP; Service persistence after exit

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -126,8 +126,8 @@
             android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver"
             android:exported="true">
             <intent-filter>
-                <action android:name="me.yashwanth.simpleftpserver.ACTION_START_FTPSERVER" />
-                <action android:name="me.yashwanth.simpleftpserver.ACTION_STOP_FTPSERVER" />
+                <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_START_FTPSERVER" />
+                <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_STOP_FTPSERVER" />
             </intent-filter>
         </receiver>
     </application>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -130,6 +130,14 @@
                 <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_STOP_FTPSERVER" />
             </intent-filter>
         </receiver>
+        <receiver
+            android:name="com.amaze.filemanager.ui.notifications.FTPNotification"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.FTPSERVER_STARTED" />
+                <action android:name="com.amaze.filemanager.services.ftpservice.FTPReceiver.FTPSERVER_STOPPED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
+++ b/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
@@ -29,11 +29,7 @@ import com.amaze.filemanager.utils.PreferenceUtils;
 import org.w3c.dom.Text;
 
 /**
-<<<<<<< HEAD
  * Created by yashwanthreddyg on 10-06-2016.
-=======
- * Created by KH9151 on 10-06-2016.
->>>>>>> e5a0d0bd685bba3a1322d7c0ff416f1334451f9b
  */
 public class FTPServerFragment extends Fragment {
 

--- a/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
+++ b/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
@@ -64,7 +64,7 @@ public class FTPServerFragment extends Fragment {
             if(action == FTPService.ACTION_STARTED) {
                 statusText.setText(utils.getString(getContext(), R.string.ftp_status_running));
                 warningText.setText("");
-                ftpAddrText.setText("ftp:/"+FTPService.getLocalInetAddress(getContext())+":"+FTPService.getPort());
+                ftpAddrText.setText(getFTPAddressString());
                 ftpBtn.setText(utils.getString(getContext(),R.string.stop_ftp));
             }
             else if(action == FTPService.ACTION_FAILEDTOSTART){
@@ -164,11 +164,14 @@ public class FTPServerFragment extends Fragment {
         if(FTPService.isRunning()){
             statusText.setText(utils.getString(getContext(),R.string.ftp_status_running));
             ftpBtn.setText(utils.getString(getContext(),R.string.stop_ftp));
-            ftpAddrText.setText("ftp:/"+FTPService.getLocalInetAddress(getContext())+":"+FTPService.getPort());
+            ftpAddrText.setText(getFTPAddressString());
         }
         else{
             statusText.setText(utils.getString(getContext(),R.string.ftp_status_not_running));
             ftpBtn.setText(utils.getString(getContext(),R.string.start_ftp));
         }
+    }
+    private String getFTPAddressString(){
+        return "ftp://"+FTPService.getLocalInetAddress(getContext()).getHostAddress()+":"+FTPService.getPort();
     }
 }

--- a/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
+++ b/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
@@ -164,6 +164,7 @@ public class FTPServerFragment extends Fragment {
         if(FTPService.isRunning()){
             statusText.setText(utils.getString(getContext(),R.string.ftp_status_running));
             ftpBtn.setText(utils.getString(getContext(),R.string.stop_ftp));
+            ftpAddrText.setText("ftp:/"+FTPService.getLocalInetAddress(getContext())+":"+FTPService.getPort());
         }
         else{
             statusText.setText(utils.getString(getContext(),R.string.ftp_status_not_running));

--- a/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
+++ b/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
@@ -4,6 +4,9 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
+import android.graphics.drawable.Drawable;
+import android.media.Image;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Bundle;
@@ -14,6 +17,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -98,6 +102,19 @@ public class FTPServerFragment extends Fragment {
         ftpAddrText = (TextView) rootView.findViewById(R.id.ftpAddressText);
         ftpBtn = (Button) rootView.findViewById(R.id.startStopButton);
 
+        SharedPreferences Sp = PreferenceManager.getDefaultSharedPreferences(getContext());
+        int th = Integer.parseInt(Sp.getString("theme", "0"));
+        // checking if theme should be set light/dark or automatic
+        int theme1 = th == 2 ? PreferenceUtils.hourOfDay() : th;
+        ImageView ftpImage = (ImageView)rootView.findViewById(R.id.ftp_image);
+
+        //light theme
+        if(theme1 == 0){
+            ftpImage.setImageResource(R.drawable.ic_ftp_light);
+        }else{
+            //dark
+            ftpImage.setImageResource(R.drawable.ic_ftp_dark);
+        }
         ftpBtn.setOnClickListener(new View.OnClickListener(){
 
             @Override

--- a/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
+++ b/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
@@ -118,6 +118,7 @@ public class FTPService extends Service implements Runnable{
         }
         ListenerFactory fac = new ListenerFactory();
 
+        //check ports for availability
         for(int i=2211;i<65000;i++){
             if(isPortAvailable(i)) {
                 port = i;
@@ -198,6 +199,7 @@ public class FTPService extends Service implements Runnable{
         } catch (InterruptedException ignored) {
         }
     }
+
 
     public static boolean isConnectedToLocalNetwork(Context context) {
         boolean connected = false;

--- a/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
+++ b/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
@@ -41,13 +41,13 @@ public class FTPService extends Service implements Runnable{
     private static final String TAG = FTPService.class.getSimpleName();
     private static int port = 2211;;
     // Service will (global) broadcast when server start/stop
-    static public final String ACTION_STARTED = "me.yashwanth.simpleftpserver.FTPSERVER_STARTED";
-    static public final String ACTION_STOPPED = "me.yashwanth.simpleftpserver.FTPSERVER_STOPPED";
-    static public final String ACTION_FAILEDTOSTART = "me.yashwanth.simpleftpserver.FTPSERVER_FAILEDTOSTART";
+    static public final String ACTION_STARTED = "com.amaze.filemanager.services.ftpservice.FTPReceiver.FTPSERVER_STARTED";
+    static public final String ACTION_STOPPED = "com.amaze.filemanager.services.ftpservice.FTPReceiver.FTPSERVER_STOPPED";
+    static public final String ACTION_FAILEDTOSTART = "com.amaze.filemanager.services.ftpservice.FTPReceiver.FTPSERVER_FAILEDTOSTART";
 
     // RequestStartStopReceiver listens for these actions to start/stop this server
-    static public final String ACTION_START_FTPSERVER = "me.yashwanth.simpleftpserver.ACTION_START_FTPSERVER";
-    static public final String ACTION_STOP_FTPSERVER = "me.yashwanth.simpleftpserver.ACTION_STOP_FTPSERVER";
+    static public final String ACTION_START_FTPSERVER = "com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_START_FTPSERVER";
+    static public final String ACTION_STOP_FTPSERVER = "com.amaze.filemanager.services.ftpservice.FTPReceiver.ACTION_STOP_FTPSERVER";
     private String username,password;
     private boolean isPasswordProtected = false;
     protected boolean shouldExit = false;

--- a/src/main/java/com/amaze/filemanager/ui/notifications/FTPNotification.java
+++ b/src/main/java/com/amaze/filemanager/ui/notifications/FTPNotification.java
@@ -1,0 +1,111 @@
+package com.amaze.filemanager.ui.notifications;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+
+
+import com.amaze.filemanager.R;
+import com.amaze.filemanager.activities.MainActivity;
+import com.amaze.filemanager.services.ftpservice.FTPService;
+import com.amaze.filemanager.utils.Futils;
+
+import java.net.InetAddress;
+
+/**
+ * Created by yashwanthreddyg on 19-06-2016.
+ */
+public class FTPNotification extends BroadcastReceiver{
+
+    private static final int NOTIFICATION_ID = 2123;
+    Futils utils = new Futils();
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        switch(intent.getAction()){
+            case FTPService.ACTION_STARTED:
+                createNotification(context);
+                break;
+            case FTPService.ACTION_STOPPED:
+                removeNotifiation(context);
+                break;
+        }
+    }
+
+    @SuppressWarnings("NewApi")
+    private void createNotification(Context context){
+        // Get NotificationManager reference
+        String ns = Context.NOTIFICATION_SERVICE;
+        NotificationManager nm = (NotificationManager) context.getSystemService(ns);
+
+        // get ip address
+        InetAddress address = FTPService.getLocalInetAddress(context);
+
+        String iptext = "ftp://" + address.getHostAddress() + ":"
+                + FTPService.getPort() + "/";
+
+        // Instantiate a Notification
+        int icon = R.drawable.ic_ftp_light;
+        CharSequence tickerText = utils.getString(context,R.string.ftp_notif_starting);
+        long when = System.currentTimeMillis();
+
+        // Define Notification's message and Intent
+        CharSequence contentTitle = utils.getString(context,R.string.ftp_notif_title);
+        CharSequence contentText = String.format(utils.getString(context,R.string.ftp_notif_text), iptext);
+
+        Intent notificationIntent = new Intent(context, MainActivity.class);
+        notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
+
+        int stopIcon = android.R.drawable.ic_menu_close_clear_cancel;
+        CharSequence stopText = utils.getString(context,R.string.ftp_notif_stop_server);
+        Intent stopIntent = new Intent(FTPService.ACTION_STOP_FTPSERVER);
+        PendingIntent stopPendingIntent = PendingIntent.getBroadcast(context, 0,
+                stopIntent, PendingIntent.FLAG_ONE_SHOT);
+
+//        int preferenceIcon = android.R.drawable.ic_menu_preferences;
+//        CharSequence preferenceText = context.getString(R.string.notif_settings_text);
+//        Intent preferenceIntent = new Intent(context, FsPreferenceActivity.class);
+//        preferenceIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+//        PendingIntent preferencePendingIntent = PendingIntent.getActivity(context, 0, preferenceIntent, 0);
+
+        Notification.Builder nb = new Notification.Builder(context)
+                .setContentTitle(contentTitle)
+                .setContentText(contentText)
+                .setContentIntent(contentIntent)
+                .setSmallIcon(icon)
+                .setTicker(tickerText)
+                .setWhen(when)
+                .setOngoing(true);
+
+        Notification notification = null;
+
+        // go from hight to low android version adding extra options
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            nb.setVisibility(Notification.VISIBILITY_PUBLIC);
+            nb.setCategory(Notification.CATEGORY_SERVICE);
+            nb.setPriority(Notification.PRIORITY_MAX);
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            nb.addAction(stopIcon, stopText, stopPendingIntent);
+//            nb.addAction(preferenceIcon, preferenceText, preferencePendingIntent);
+            nb.setShowWhen(false);
+            notification = nb.build();
+        } else {
+            notification = nb.getNotification();
+        }
+
+        // Pass Notification to NotificationManager
+        nm.notify(NOTIFICATION_ID, notification);
+
+    }
+
+    private void removeNotifiation(Context context){
+        String ns = Context.NOTIFICATION_SERVICE;
+        NotificationManager nm = (NotificationManager) context.getSystemService(ns);
+        nm.cancelAll();
+    }
+}

--- a/src/main/java/com/amaze/filemanager/ui/notifications/FTPNotification.java
+++ b/src/main/java/com/amaze/filemanager/ui/notifications/FTPNotification.java
@@ -38,8 +38,8 @@ public class FTPNotification extends BroadcastReceiver{
     @SuppressWarnings("NewApi")
     private void createNotification(Context context){
 
-        String ns = Context.NOTIFICATION_SERVICE;
-        NotificationManager nm = (NotificationManager) context.getSystemService(ns);
+        String notificationService = Context.NOTIFICATION_SERVICE;
+        NotificationManager notificationManager = (NotificationManager) context.getSystemService(notificationService);
 
         InetAddress address = FTPService.getLocalInetAddress(context);
 
@@ -65,7 +65,7 @@ public class FTPNotification extends BroadcastReceiver{
                 stopIntent, PendingIntent.FLAG_ONE_SHOT);
 
 
-        Notification.Builder nb = new Notification.Builder(context)
+        Notification.Builder notificationBuilder = new Notification.Builder(context)
                 .setContentTitle(contentTitle)
                 .setContentText(contentText)
                 .setContentIntent(contentIntent)
@@ -78,20 +78,20 @@ public class FTPNotification extends BroadcastReceiver{
 
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            nb.setVisibility(Notification.VISIBILITY_PUBLIC);
-            nb.setCategory(Notification.CATEGORY_SERVICE);
-            nb.setPriority(Notification.PRIORITY_MAX);
+            notificationBuilder.setVisibility(Notification.VISIBILITY_PUBLIC);
+            notificationBuilder.setCategory(Notification.CATEGORY_SERVICE);
+            notificationBuilder.setPriority(Notification.PRIORITY_MAX);
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            nb.addAction(stopIcon, stopText, stopPendingIntent);
-            nb.setShowWhen(false);
-            notification = nb.build();
+            notificationBuilder.addAction(stopIcon, stopText, stopPendingIntent);
+            notificationBuilder.setShowWhen(false);
+            notification = notificationBuilder.build();
         } else {
-            notification = nb.getNotification();
+            notification = notificationBuilder.getNotification();
         }
 
         // Pass Notification to NotificationManager
-        nm.notify(NOTIFICATION_ID, notification);
+        notificationManager.notify(NOTIFICATION_ID, notification);
 
     }
 

--- a/src/main/java/com/amaze/filemanager/ui/notifications/FTPNotification.java
+++ b/src/main/java/com/amaze/filemanager/ui/notifications/FTPNotification.java
@@ -30,29 +30,27 @@ public class FTPNotification extends BroadcastReceiver{
                 createNotification(context);
                 break;
             case FTPService.ACTION_STOPPED:
-                removeNotifiation(context);
+                removeNotification(context);
                 break;
         }
     }
 
     @SuppressWarnings("NewApi")
     private void createNotification(Context context){
-        // Get NotificationManager reference
+
         String ns = Context.NOTIFICATION_SERVICE;
         NotificationManager nm = (NotificationManager) context.getSystemService(ns);
 
-        // get ip address
         InetAddress address = FTPService.getLocalInetAddress(context);
 
         String iptext = "ftp://" + address.getHostAddress() + ":"
                 + FTPService.getPort() + "/";
 
-        // Instantiate a Notification
         int icon = R.drawable.ic_ftp_light;
         CharSequence tickerText = utils.getString(context,R.string.ftp_notif_starting);
         long when = System.currentTimeMillis();
 
-        // Define Notification's message and Intent
+
         CharSequence contentTitle = utils.getString(context,R.string.ftp_notif_title);
         CharSequence contentText = String.format(utils.getString(context,R.string.ftp_notif_text), iptext);
 
@@ -66,11 +64,6 @@ public class FTPNotification extends BroadcastReceiver{
         PendingIntent stopPendingIntent = PendingIntent.getBroadcast(context, 0,
                 stopIntent, PendingIntent.FLAG_ONE_SHOT);
 
-//        int preferenceIcon = android.R.drawable.ic_menu_preferences;
-//        CharSequence preferenceText = context.getString(R.string.notif_settings_text);
-//        Intent preferenceIntent = new Intent(context, FsPreferenceActivity.class);
-//        preferenceIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-//        PendingIntent preferencePendingIntent = PendingIntent.getActivity(context, 0, preferenceIntent, 0);
 
         Notification.Builder nb = new Notification.Builder(context)
                 .setContentTitle(contentTitle)
@@ -83,7 +76,7 @@ public class FTPNotification extends BroadcastReceiver{
 
         Notification notification = null;
 
-        // go from hight to low android version adding extra options
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             nb.setVisibility(Notification.VISIBILITY_PUBLIC);
             nb.setCategory(Notification.CATEGORY_SERVICE);
@@ -91,7 +84,6 @@ public class FTPNotification extends BroadcastReceiver{
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             nb.addAction(stopIcon, stopText, stopPendingIntent);
-//            nb.addAction(preferenceIcon, preferenceText, preferencePendingIntent);
             nb.setShowWhen(false);
             notification = nb.build();
         } else {
@@ -103,7 +95,7 @@ public class FTPNotification extends BroadcastReceiver{
 
     }
 
-    private void removeNotifiation(Context context){
+    private void removeNotification(Context context){
         String ns = Context.NOTIFICATION_SERVICE;
         NotificationManager nm = (NotificationManager) context.getSystemService(ns);
         nm.cancelAll();

--- a/src/main/res/layout/fragment_ftp.xml
+++ b/src/main/res/layout/fragment_ftp.xml
@@ -6,7 +6,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceMedium"
-        android:text="Medium Text"
+        android:text=""
         android:id="@+id/statusText"
         android:layout_above="@+id/startStopButton"
         android:layout_centerHorizontal="true"
@@ -34,7 +34,7 @@
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textColor="@color/primary_red"
-        android:text="Medium Text"
+        android:text=""
         android:id="@+id/warningText"
         android:layout_above="@+id/startStopButton"
         android:layout_centerHorizontal="true" />

--- a/src/main/res/layout/fragment_ftp.xml
+++ b/src/main/res/layout/fragment_ftp.xml
@@ -6,7 +6,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceMedium"
-        android:text="status"
+        android:text=""
         android:id="@+id/statusText"
         android:layout_above="@+id/startStopButton"
         android:layout_centerHorizontal="true"
@@ -16,7 +16,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceLarge"
-        android:text="addr"
+        android:text=""
         android:id="@+id/ftpAddressText"
         android:layout_below="@+id/startStopButton"
         android:layout_centerHorizontal="true" />
@@ -34,7 +34,7 @@
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textColor="@color/primary_red"
-        android:text="warn"
+        android:text=""
         android:id="@+id/warningText"
         android:layout_above="@+id/startStopButton"
         android:layout_centerHorizontal="true" />

--- a/src/main/res/layout/fragment_ftp.xml
+++ b/src/main/res/layout/fragment_ftp.xml
@@ -6,7 +6,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceMedium"
-        android:text=""
+        android:text="status"
         android:id="@+id/statusText"
         android:layout_above="@+id/startStopButton"
         android:layout_centerHorizontal="true"
@@ -16,7 +16,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceLarge"
-        android:text=""
+        android:text="addr"
         android:id="@+id/ftpAddressText"
         android:layout_below="@+id/startStopButton"
         android:layout_centerHorizontal="true" />
@@ -34,8 +34,15 @@
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textColor="@color/primary_red"
-        android:text=""
+        android:text="warn"
         android:id="@+id/warningText"
         android:layout_above="@+id/startStopButton"
+        android:layout_centerHorizontal="true" />
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/ftp_image"
+        android:layout_above="@+id/warningText"
         android:layout_centerHorizontal="true" />
 </RelativeLayout>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -404,7 +404,7 @@
     <string name="ftp_status_not_running">Not Running</string>
     <string name="ftp_no_wifi">Make sure you\'re connected to WiFi</string>
     <string name="ftp_notif_starting">FTP Server is starting</string>
-    <string name="ftp_notif_title">FTP Server started</string>
+    <string name="ftp_notif_title">Amaze FTP Server running</string>
     <string name="ftp_notif_text">at %s</string>
     <string name="ftp_notif_stop_server">STOP</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -403,5 +403,9 @@
     <string name="ftp_status_running">Running</string>
     <string name="ftp_status_not_running">Not Running</string>
     <string name="ftp_no_wifi">Make sure you\'re connected to WiFi</string>
+    <string name="ftp_notif_starting">FTP Server is starting</string>
+    <string name="ftp_notif_title">FTP Server started</string>
+    <string name="ftp_notif_text">at %s</string>
+    <string name="ftp_notif_stop_server">STOP</string>
 </resources>
 


### PR DESCRIPTION
1. Added Notification for stopping the FTPService running in the background
2. FTPService will now run in the background even if the app is closed from the recents screen.
3. Added an image in the fragment for ftp (Added the default ic_ftp_* image, needs to be replaced with a bigger and better looking one).
4. Minor code refactoring.