### PR TITLE
Fix navigation drawer scrolling

### DIFF
--- a/src/main/res/layout-v21/main_toolbar.xml
+++ b/src/main/res/layout-v21/main_toolbar.xml
@@ -320,6 +320,7 @@
         <ImageView
             android:layout_width="match_parent"
             android:layout_height="9dp"
+            android:clickable="true"
             android:paddingBottom="8dp"
             android:src="@color/divider"
             android:background="@android:color/transparent"

--- a/src/main/res/layout/main_toolbar.xml
+++ b/src/main/res/layout/main_toolbar.xml
@@ -327,6 +327,7 @@
         <ImageView
             android:layout_width="match_parent"
             android:layout_height="9dp"
+            android:clickable="true"
             android:paddingTop="0dp"
             android:paddingBottom="8dp"
             android:src="@color/divider"


### PR DESCRIPTION
When the navigation drawer was open it was possible to scroll underlying
content by touching the area above FTP button.

This is the demonstration of the issue:
![drawer-scrolling](https://cloud.githubusercontent.com/assets/1196012/20781165/90bc3022-b7a2-11e6-97c9-05926de64fb4.gif)
