### PR TITLE
Update CircleGradientDrawable: Use device density to transform dp to px

### DIFF
--- a/src/main/java/com/amaze/filemanager/ui/views/CircleGradientDrawable.java
+++ b/src/main/java/com/amaze/filemanager/ui/views/CircleGradientDrawable.java
@@ -2,6 +2,7 @@ package com.amaze.filemanager.ui.views;
 
 import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
+import android.support.annotation.ColorInt;
 import android.util.DisplayMetrics;
 
 import com.amaze.filemanager.utils.theme.AppTheme;
@@ -20,21 +21,40 @@ public class CircleGradientDrawable extends GradientDrawable {
 
     /**
      * Constructor
-     * @param color the hex color of circular icon
+     *
+     * @param color    the hex color of circular icon
      * @param appTheme current theme light/dark which will determine the boundary color
-     * @param metrics to convert the boundary width for {@link #setStroke} method from dp to px
+     * @param metrics  to convert the boundary width for {@link #setStroke} method from dp to px
      */
     public CircleGradientDrawable(String color, AppTheme appTheme, DisplayMetrics metrics) {
+        this(appTheme, metrics);
+        setColor(Color.parseColor(color));
+    }
+
+    /**
+     * Constructor
+     *
+     * @param color    the color of circular icon
+     * @param appTheme current theme light/dark which will determine the boundary color
+     * @param metrics  to convert the boundary width for {@link #setStroke} method from dp to px
+     */
+    public CircleGradientDrawable(@ColorInt int color, AppTheme appTheme, DisplayMetrics metrics) {
+        this(appTheme, metrics);
+        setColor(color);
+    }
+
+
+    public CircleGradientDrawable(AppTheme appTheme, DisplayMetrics metrics) {
         this.mDisplayMetrics = metrics;
+
         setShape(OVAL);
         setSize(1, 1);
-        setColor(Color.parseColor(color));
         setStroke(dpToPx(STROKE_WIDTH), (appTheme.equals(AppTheme.DARK)) ? Color.parseColor(STROKE_COLOR_DARK)
                 : Color.parseColor(STROKE_COLOR_LIGHT));
     }
 
     private int dpToPx(int dp) {
-        int px = Math.round(dp * mDisplayMetrics.xdpi/mDisplayMetrics.DENSITY_DEFAULT);
+        int px = Math.round(mDisplayMetrics.density * dp);
         return px;
     }
 }


### PR DESCRIPTION
Use screen density instead of default to compute px from dp