### PR TITLE
AmazeFileManager: Fix app name color at app manager 

### DIFF
--- a/src/main/java/com/amaze/filemanager/adapters/AppsAdapter.java
+++ b/src/main/java/com/amaze/filemanager/adapters/AppsAdapter.java
@@ -144,7 +144,7 @@ public class AppsAdapter extends ArrayAdapter<Layoutelements> {
             final ViewHolder vholder = new ViewHolder();
             vholder.txtTitle = (TextView) view.findViewById(R.id.firstline);
             if (utilsProvider.getAppTheme().equals(AppTheme.LIGHT))
-                vholder.txtTitle.setTextColor(Color.WHITE);
+                vholder.txtTitle.setTextColor(Color.BLACK);
             vholder.apkIcon = (ImageView) view.findViewById(R.id.apk_icon);
             vholder.rl = (RelativeLayout) view.findViewById(R.id.second);
             vholder.txtDesc= (TextView) view.findViewById(R.id.date);


### PR DESCRIPTION
if current theme is light style, app name should be black color

Change-Id: If98fc6762d16193f9b59ae387be678e12a470926