### PR TITLE
Encode username and password separately for SMB URIs. Closes Issue #429

### DIFF
--- a/src/main/java/com/amaze/filemanager/ui/dialogs/RenameBookmark.java
+++ b/src/main/java/com/amaze/filemanager/ui/dialogs/RenameBookmark.java
@@ -157,7 +157,7 @@ public class RenameBookmark extends DialogFragment {
                             URL a = new URL(t);
                             String userinfo = a.getUserInfo();
                             if (userinfo == null && user.length() > 0) {
-                                t = "smb://" + ((URLEncoder.encode(user + ":" + pass, "UTF-8") + "@")) + a.getHost() +a.getPath();
+                                t = "smb://" + ((URLEncoder.encode(user, "UTF-8") + ":" + URLEncoder.encode(pass, "UTF-8") + "@")) + a.getHost() +a.getPath();
                             }
                         } catch (Exception e) {
                             e.printStackTrace();

--- a/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
+++ b/src/main/java/com/amaze/filemanager/ui/dialogs/SmbConnectDialog.java
@@ -15,6 +15,7 @@ import android.support.v7.widget.AppCompatCheckBox;
 import android.support.v7.widget.AppCompatEditText;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -39,6 +40,8 @@ import jcifs.smb.SmbFile;
  */
 public class SmbConnectDialog extends DialogFragment {
     private UtilitiesProviderInterface utilsProvider;
+
+    private static final String TAG = "SmbConnectDialog";
 
 
     public interface SmbConnectionListener{
@@ -298,7 +301,7 @@ public class SmbConnectDialog extends DialogFragment {
     public SmbFile connectingWithSmbServer(String[] auth, boolean anonym) {
         try {
             String yourPeerIP = auth[0], domain = auth[3];
-            String path = "smb://"+(android.text.TextUtils.isEmpty(domain) ? "" :( URLEncoder.encode(domain + ";","UTF-8")) )+ (anonym ? "" : (URLEncoder.encode(auth[1] + ":" + auth[2], "UTF-8") + "@")) + yourPeerIP + "/";
+            String path = "smb://"+(android.text.TextUtils.isEmpty(domain) ? "" :( URLEncoder.encode(domain + ";","UTF-8")) )+ (anonym ? "" : (URLEncoder.encode(auth[1], "UTF-8") + ":" + URLEncoder.encode(auth[2], "UTF-8") + "@")) + yourPeerIP + "/";
             SmbFile smbFile = new SmbFile(path);
             return smbFile;
         } catch (Exception e) {


### PR DESCRIPTION
This allows remote videos to be loaded with more video players.

Tested with:

MX Player
BS Player
VLC Media Player
ES Media Player