### PR TITLE
make toolbar intellihide configureable (#486)

### DIFF
--- a/src/main/java/com/amaze/filemanager/fragments/Main.java
+++ b/src/main/java/com/amaze/filemanager/fragments/Main.java
@@ -273,6 +273,13 @@ public class Main extends android.support.v4.app.Fragment {
         itemsstring = res.getString(R.string.items);
         apk = new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.ic_doc_apk_grid));
         mToolbarContainer.setBackgroundColor(MainActivity.currentTab==1 ? skinTwoColor : skin_color);
+
+        if (!Sp.getBoolean("intelliHideToolbar", true)){
+            AppBarLayout.LayoutParams params = (AppBarLayout.LayoutParams) getActivity().findViewById(R.id.action_bar).getLayoutParams();
+            params.setScrollFlags(0);
+            mToolbarContainer.setExpanded(true, true);
+        }
+
         //   listView.setPadding(listView.getPaddingLeft(), paddingTop, listView.getPaddingRight(), listView.getPaddingBottom());
         return rootView;
     }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -589,5 +589,7 @@
     <string name="field_empty">Field can\'t be empty</string>
     <string name="ftp_timeout">Idle timeout</string>
     <string name="ftp_seconds">Seconds</string>
+    <string name="intellihide_toolbar_title">Intellihide Toolbar</string>
+    <string name="intellihide_toolbar_summary">Automatically hide toolbar while scrolling</string>
 </resources>
 

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -42,6 +42,12 @@
             android:defaultValue="true"
             android:key="showDividers"
             android:title="@string/showDividers"/>
+        <com.amaze.filemanager.ui.views.CheckBx
+            android:defaultValue="true"
+            android:key="intelliHideToolbar"
+            android:summary="@string/intellihide_toolbar_summary"
+            android:title="@string/intellihide_toolbar_title"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/general">


### PR DESCRIPTION
Regarding issue #486.  
Allow to disable autohiding of toolbar.  
Default behaviour (autohide enabled) remains untouched.  
User now has option to disable autohiding in Preferences, going back from Preference-Activity applies it automatically.