### PR TITLE
Changed how ThemedImageView works and solved black shortcut items on dark theme

### DIFF
--- a/src/main/java/com/amaze/filemanager/ui/views/ThemedImageButton.java
+++ b/src/main/java/com/amaze/filemanager/ui/views/ThemedImageButton.java
@@ -1,0 +1,37 @@
+package com.amaze.filemanager.ui.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.ImageButton;
+
+/**
+ * @author Emmanuel
+ *         on 8/5/2017, at 13:39.
+ */
+
+public class ThemedImageButton extends ThemedImageView {
+
+    public ThemedImageButton(Context context) {
+        super(context);
+    }
+
+    public ThemedImageButton(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ThemedImageButton(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setFocusable(true);
+    }
+
+    @Override
+    protected boolean onSetAlpha(int alpha) {
+        return false;
+    }
+
+    @Override
+    public CharSequence getAccessibilityClassName() {
+        return ImageButton.class.getName();
+    }
+
+}

--- a/src/main/java/com/amaze/filemanager/ui/views/ThemedImageView.java
+++ b/src/main/java/com/amaze/filemanager/ui/views/ThemedImageView.java
@@ -1,12 +1,12 @@
 package com.amaze.filemanager.ui.views;
 
+import android.app.Activity;
 import android.content.Context;
-import android.content.res.TypedArray;
+import android.content.ContextWrapper;
+import android.graphics.Color;
 import android.util.AttributeSet;
-import android.widget.ImageView;
 
-import com.amaze.filemanager.R;
-import com.amaze.filemanager.activities.MainActivity;
+import com.amaze.filemanager.activities.BasicActivity;
 import com.amaze.filemanager.utils.theme.AppTheme;
 
 /**
@@ -29,13 +29,26 @@ public class ThemedImageView extends android.support.v7.widget.AppCompatImageVie
     public ThemedImageView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
 
-        // Load attributes
-        TypedArray array = getContext().obtainStyledAttributes(attrs, R.styleable.ImageView, defStyleAttr, 0);
+        BasicActivity a = (BasicActivity) getActivity();
 
         // dark preference found
-        if (((MainActivity) context).getAppTheme().equals(AppTheme.DARK))
-            setImageDrawable(array.getDrawable(R.styleable.ImageView_src_dark));
+        if (a != null && a.getAppTheme().equals(AppTheme.DARK)) {
+            setColorFilter(Color.argb(255, 255, 255, 255)); // White Tint
+        } else if (a == null) {
+            throw new IllegalStateException("Could not get activity! Can't show correct icon color!");
+        }
 
-        array.recycle();
     }
+
+    private Activity getActivity() {
+        Context context = getContext();
+        while (context instanceof ContextWrapper) {
+            if (context instanceof Activity) {
+                return (Activity)context;
+            }
+            context = ((ContextWrapper)context).getBaseContext();
+        }
+        return null;
+    }
+
 }

--- a/src/main/res/layout/dialog_decrypt_fingerprint_authentication.xml
+++ b/src/main/res/layout/dialog_decrypt_fingerprint_authentication.xml
@@ -11,7 +11,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:src="@drawable/ic_fingerprint_grey600_36dp"
-        app:src_dark="@drawable/ic_fingerprint_white_36dp"
         />
 
     <com.amaze.filemanager.ui.views.ThemedTextView

--- a/src/main/res/layout/fragment_sheet_cloud.xml
+++ b/src/main/res/layout/fragment_sheet_cloud.xml
@@ -41,7 +41,6 @@
             >
             <com.amaze.filemanager.ui.views.ThemedImageView
                 android:src="@drawable/ic_remote_grey600_24dp"
-                app:src_dark="@drawable/ic_remote_white_24dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginRight="@dimen/material_generic_medium"
@@ -66,7 +65,6 @@
             >
             <com.amaze.filemanager.ui.views.ThemedImageView
                 android:src="@drawable/ic_dropbox_grey600_24dp"
-                app:src_dark="@drawable/ic_dropbox_white_24dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginRight="@dimen/material_generic_medium"
@@ -91,7 +89,6 @@
             >
             <com.amaze.filemanager.ui.views.ThemedImageView
                 android:src="@drawable/ic_box_grey600_24dp"
-                app:src_dark="@drawable/ic_box_white_24dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginRight="@dimen/material_generic_medium"
@@ -116,7 +113,6 @@
             >
             <com.amaze.filemanager.ui.views.ThemedImageView
                 android:src="@drawable/ic_google_drive_grey600_24dp"
-                app:src_dark="@drawable/ic_google_drive_white_24dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginRight="@dimen/material_generic_medium"
@@ -141,7 +137,6 @@
             >
             <com.amaze.filemanager.ui.views.ThemedImageView
                 android:src="@drawable/ic_onedrive_grey600_24dp"
-                app:src_dark="@drawable/ic_onedrive_white_24dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginRight="@dimen/material_generic_medium"
@@ -166,7 +161,6 @@
             >
             <com.amaze.filemanager.ui.views.ThemedImageView
                 android:src="@drawable/ic_onedrive_grey600_24dp"
-                app:src_dark="@drawable/ic_onedrive_white_24dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginRight="@dimen/material_generic_medium"

--- a/src/main/res/layout/namepathswich_preference.xml
+++ b/src/main/res/layout/namepathswich_preference.xml
@@ -8,7 +8,7 @@
               android:paddingLeft="16dip"
               android:paddingStart="16dip">
 
-    <com.amaze.filemanager.ui.views.ThemedImageView
+    <com.amaze.filemanager.ui.views.ThemedImageButton
         android:id="@+id/edit"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -25,7 +25,7 @@
         android:layout_gravity="center"
         />
 
-    <com.amaze.filemanager.ui.views.ThemedImageView
+    <com.amaze.filemanager.ui.views.ThemedImageButton
         android:id="@+id/delete"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/src/main/res/layout/namepathswich_preference.xml
+++ b/src/main/res/layout/namepathswich_preference.xml
@@ -8,7 +8,7 @@
               android:paddingLeft="16dip"
               android:paddingStart="16dip">
 
-    <ImageButton
+    <com.amaze.filemanager.ui.views.ThemedImageView
         android:id="@+id/edit"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -25,7 +25,7 @@
         android:layout_gravity="center"
         />
 
-    <ImageButton
+    <com.amaze.filemanager.ui.views.ThemedImageView
         android:id="@+id/delete"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/src/main/res/values/attrs.xml
+++ b/src/main/res/values/attrs.xml
@@ -31,8 +31,4 @@
         <attr name="animationDuration" format="integer" />
         <attr name="currentPageIndicatorColor" format="color" />
     </declare-styleable>
-
-    <declare-styleable name="ImageView">
-        <attr name="src_dark" format="reference" />
-    </declare-styleable>
 </resources>


### PR DESCRIPTION
Changed how ThemedImageView works, not very fundamental, but now it sets a color filter that's white (#FFFFFFFF) instead of using another image, changed layouts accordingly, but left the old png's.
Also, now shortcut preferences have white icon when on dark theme.