### PR TITLE
Allow FTP service to run when wifi AP is enabled

### DIFF
--- a/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
+++ b/src/main/java/com/amaze/filemanager/fragments/FTPServerFragment.java
@@ -122,7 +122,9 @@ public class FTPServerFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 if (!FTPService.isRunning()) {
-                    if (FTPService.isConnectedToWifi(getContext()) || FTPService.isConnectedToLocalNetwork(getContext()))
+                    if (FTPService.isConnectedToWifi(getContext())
+                            || FTPService.isConnectedToLocalNetwork(getContext())
+                            || FTPService.isEnabledWifiHotspot(getContext()))
                         startServer();
                     else {
                         // no wifi and no eth, we shouldn't be here in the first place, because of broadcast
@@ -342,7 +344,8 @@ public class FTPServerFragment extends Fragment {
         public void onReceive(Context context, Intent intent) {
             ConnectivityManager conMan = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
             NetworkInfo netInfo = conMan.getActiveNetworkInfo();
-            if (netInfo != null && (netInfo.getType() == ConnectivityManager.TYPE_WIFI || netInfo.getType() == ConnectivityManager.TYPE_ETHERNET)) {
+            if ((netInfo != null && (netInfo.getType() == ConnectivityManager.TYPE_WIFI || netInfo.getType() == ConnectivityManager.TYPE_ETHERNET))
+                    || FTPService.isEnabledWifiHotspot(getContext())) {
                 // connected to wifi or eth
                 ftpBtn.setEnabled(true);
             } else {
@@ -423,7 +426,9 @@ public class FTPServerFragment extends Fragment {
     private void updateStatus() {
 
         if (!FTPService.isRunning()) {
-            if (!FTPService.isConnectedToWifi(getContext()) && !FTPService.isConnectedToLocalNetwork(getContext())) {
+            if (!FTPService.isConnectedToWifi(getContext())
+                    && !FTPService.isConnectedToLocalNetwork(getContext())
+                    && !FTPService.isEnabledWifiHotspot(getContext())) {
                 statusText.setText(spannedStatusNoConnection);
                 ftpBtn.setEnabled(false);
             } else {
@@ -502,7 +507,7 @@ public class FTPServerFragment extends Fragment {
         InetAddress ia = FTPService.getLocalInetAddress(getContext());
         if (ia != null)
             hostAddress = ia.getHostAddress();
-        return "ftp://" + hostAddress  + ":" + FTPService.getPort();
+        return "ftp://" + hostAddress  + ":" + FTPService.getPort(getContext());
     }
 
     private int getDefaultPortFromPreferences() {

--- a/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
+++ b/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
@@ -255,16 +255,6 @@ public class FTPService extends Service implements Runnable {
                 && ni.isConnected()
                 && (ni.getType() & (ConnectivityManager.TYPE_WIFI | ConnectivityManager.TYPE_ETHERNET)) != 0;
         if (!connected) {
-            Log.d(TAG, "isConnectedToLocalNetwork: see if it is an WIFI AP");
-            WifiManager wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
-            try {
-                Method method = wm.getClass().getDeclaredMethod("isWifiApEnabled");
-                connected = (Boolean) method.invoke(wm);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-        if (!connected) {
             Log.d(TAG, "isConnectedToLocalNetwork: see if it is an USB AP");
             try {
                 for (NetworkInterface netInterface : Collections.list(NetworkInterface
@@ -287,6 +277,19 @@ public class FTPService extends Service implements Runnable {
         NetworkInfo ni = cm.getActiveNetworkInfo();
         return ni != null && ni.isConnected()
                 && ni.getType() == ConnectivityManager.TYPE_WIFI;
+    }
+
+    public static boolean isEnabledWifiHotspot(Context context) {
+        boolean enabled = false;
+        Log.d(TAG, "isConnectedToLocalNetwork: see if it is an WIFI AP");
+        WifiManager wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+        try {
+            Method method = wm.getClass().getDeclaredMethod("isWifiApEnabled");
+            enabled = (Boolean) method.invoke(wm);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return enabled;
     }
 
     public static InetAddress getLocalInetAddress(Context context) {

--- a/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
+++ b/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
@@ -69,6 +69,8 @@ public class FTPService extends Service implements Runnable {
      */
     private static int port = 2211;
 
+    private static final String WIFI_AP_ADDRESS = "192.168.43.1";
+
     // Service will (global) broadcast when server start/stop
     static public final String ACTION_STARTED = "com.amaze.filemanager.services.ftpservice.FTPReceiver.FTPSERVER_STARTED";
     static public final String ACTION_STOPPED = "com.amaze.filemanager.services.ftpservice.FTPReceiver.FTPSERVER_STOPPED";
@@ -315,6 +317,11 @@ public class FTPService extends Service implements Runnable {
                 Enumeration<InetAddress> addresses = netinterface.getInetAddresses();
                 while (addresses.hasMoreElements()) {
                     InetAddress address = addresses.nextElement();
+
+                    if(isEnabledWifiHotspot(context)
+                            && WIFI_AP_ADDRESS.equals(address.getHostAddress()))
+                        return address;
+
                     // this is the condition that sometimes gives problems
                     if (!address.isLoopbackAddress()
                             && !address.isLinkLocalAddress())

--- a/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
+++ b/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
@@ -312,9 +312,9 @@ public class FTPService extends Service implements Runnable {
                     .getNetworkInterfaces();
             while (netinterfaces.hasMoreElements()) {
                 NetworkInterface netinterface = netinterfaces.nextElement();
-                Enumeration<InetAddress> adresses = netinterface.getInetAddresses();
-                while (adresses.hasMoreElements()) {
-                    InetAddress address = adresses.nextElement();
+                Enumeration<InetAddress> addresses = netinterface.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress address = addresses.nextElement();
                     // this is the condition that sometimes gives problems
                     if (!address.isLoopbackAddress()
                             && !address.isLinkLocalAddress())

--- a/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
+++ b/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
@@ -281,7 +281,7 @@ public class FTPService extends Service implements Runnable {
 
     public static boolean isEnabledWifiHotspot(Context context) {
         boolean enabled = false;
-        Log.d(TAG, "isConnectedToLocalNetwork: see if it is an WIFI AP");
+        Log.d(TAG, "isEnabledWifiHotspot: see if it is an WIFI AP");
         WifiManager wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
         try {
             Method method = wm.getClass().getDeclaredMethod("isWifiApEnabled");

--- a/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
+++ b/src/main/java/com/amaze/filemanager/services/ftpservice/FTPService.java
@@ -64,11 +64,6 @@ public class FTPService extends Service implements Runnable {
 
     private static final String TAG = FTPService.class.getSimpleName();
 
-    /**
-     * TODO: 25/10/16 This is ugly
-     */
-    private static int port = 2211;
-
     private static final String WIFI_AP_ADDRESS = "192.168.43.1";
 
     // Service will (global) broadcast when server start/stop
@@ -146,8 +141,6 @@ public class FTPService extends Service implements Runnable {
         }
         ListenerFactory fac = new ListenerFactory();
 
-        port = preferences.getInt(PORT_PREFERENCE_KEY, DEFAULT_PORT);
-
         if (preferences.getBoolean(KEY_PREFERENCE_SECURE, DEFAULT_SECURE)) {
             SslConfigurationFactory sslConfigurationFactory = new SslConfigurationFactory();
 
@@ -174,7 +167,7 @@ public class FTPService extends Service implements Runnable {
             }
         }
 
-        fac.setPort(port);
+        fac.setPort(preferences.getInt(PORT_PREFERENCE_KEY, DEFAULT_PORT));
         fac.setIdleTimeout(preferences.getInt(KEY_PREFERENCE_TIMEOUT, DEFAULT_TIMEOUT));
 
         serverFactory.addListener("default", fac.createListener());
@@ -295,7 +288,7 @@ public class FTPService extends Service implements Runnable {
     }
 
     public static InetAddress getLocalInetAddress(Context context) {
-        if (!isConnectedToLocalNetwork(context)) {
+        if (!isConnectedToLocalNetwork(context) && !isEnabledWifiHotspot(context)) {
             Log.e(TAG, "getLocalInetAddress called and no connection");
             return null;
         }
@@ -352,8 +345,10 @@ public class FTPService extends Service implements Runnable {
         return (byte) (value >> shift);
     }
 
-    public static int getPort() {
-        return port;
+    public static int getPort(Context context)
+    {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        return preferences.getInt(PORT_PREFERENCE_KEY, DEFAULT_PORT);
     }
 
     public static boolean isPortAvailable(int port) {

--- a/src/main/java/com/amaze/filemanager/ui/notifications/FTPNotification.java
+++ b/src/main/java/com/amaze/filemanager/ui/notifications/FTPNotification.java
@@ -42,7 +42,7 @@ public class FTPNotification extends BroadcastReceiver{
         InetAddress address = FTPService.getLocalInetAddress(context);
 
         String iptext = "ftp://" + address.getHostAddress() + ":"
-                + FTPService.getPort() + "/";
+                + FTPService.getPort(context) + "/";
 
         int icon = R.drawable.ic_ftp_light;
         CharSequence tickerText = context.getResources().getString(R.string.ftp_notif_starting);


### PR DESCRIPTION
This is an attempt to solve #515 which allow FTP service to run when device is running with the device's wifi AP is enabled.