### PR TITLE
Catch ActivityNotFoundException and launch web browser for app

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/AppsAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/AppsAdapter.java
@@ -20,6 +20,7 @@
 package com.amaze.filemanager.adapters;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -212,8 +213,13 @@ public class AppsAdapter extends ArrayAdapter<AppDataParcelable> {
                         return true;
                     case R.id.play:
                         Intent intent1 = new Intent(Intent.ACTION_VIEW);
-                        intent1.setData(Uri.parse(String.format("market://details?id=%s", rowItem.packageName)));
-                        app.startActivity(intent1);
+                        try {
+                            intent1.setData(Uri.parse(String.format("market://details?id=%s", rowItem.packageName)));
+                            app.startActivity(intent1);
+                        } catch (ActivityNotFoundException ifPlayStoreNotInstalled) {
+                            intent1.setData(Uri.parse(String.format("https://play.google.com/store/apps/details?id=%s", rowItem.packageName)));
+                            app.startActivity(intent1);
+                        }
                         return true;
                     case R.id.properties:
                         app.startActivity(new Intent(
@@ -243,22 +249,8 @@ public class AppsAdapter extends ArrayAdapter<AppDataParcelable> {
             });
 
             popupMenu.inflate(R.menu.app_options);
-            if(!isGooglePlayStoreAvailable()) {
-                popupMenu.getMenu().findItem(R.id.play).setVisible(false);
-            }
             popupMenu.show();
         });
 
     }
-
-    private final boolean isGooglePlayStoreAvailable() {
-        PackageManager pm = context.getPackageManager();
-        try {
-            PackageInfo appInfo = pm.getPackageInfo(COM_ANDROID_VENDING, PackageManager.GET_ACTIVITIES);
-            return appInfo != null && appInfo.activities != null;
-        } catch (PackageManager.NameNotFoundException ifNotInstalled) {
-            return false;
-        }
-    }
-
 }


### PR DESCRIPTION
Fixes #1139, app package's webpage on Google Play Store (if any) will be opened if user device does not have Google Play Store installed, which should be sufficient as almost all Android devices should have webview implementations.

Additionally
 * remove deprecated MaterialDialog.Builder.callback() to .onNegative() and .onPositive()
 * change HybridFileParcelable.getParent() to HybridFileParcelable.getParent(Context).
 * change hard-coded SDK version 21 to Build.VERSION_CODES.LOLLIPOP

Tested with Nougat emulator (no Google Play Services installed).