### PR TITLE
1946: Change white startup theme to black

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -119,7 +119,7 @@
             android:uiOptions="splitActionBarWhenNarrow"
             android:label="@string/setting"
             android:name=".ui.activities.PreferencesActivity"
-            android:theme="@style/appCompatLight">
+            android:theme="@style/appCompatBlack">
             <intent-filter>
                 <action android:name="android.intent.action.APPLICATION_PREFERENCES" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -129,7 +129,7 @@
         <activity
             android:label="@string/textreader"
             android:name=".ui.activities.TextEditorActivity"
-            android:theme="@style/appCompatLight">
+            android:theme="@style/appCompatBlack">
             <intent-filter
                 tools:ignore="AppLinkUrlError"
                 android:label="Amaze Text Editor">
@@ -145,7 +145,7 @@
         <activity
             android:label="@string/databasereader"
             android:name=".ui.activities.DatabaseViewerActivity"
-            android:theme="@style/appCompatLight"
+            android:theme="@style/appCompatBlack"
             android:screenOrientation="locked">
             <intent-filter
                 tools:ignore="AppLinkUrlError"
@@ -158,7 +158,7 @@
         </activity>
 
         <activity android:name=".ui.activities.AboutActivity"
-            android:theme="@style/aboutLight"
+            android:theme="@style/aboutBlack"
             android:label="About"
             />
 


### PR DESCRIPTION
## PR Info
#### Issue tracker   
Fixes will automatically close the related issue

Fixes #1946 
-or-   
Addresses #

#### Release  
Addresses release/3.5
  
#### Test cases
- [ ] Covered
  
#### Manual testing
- [x] Done  
  
If yes,  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local 
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #

#### Additional Info
Change default to black as white on black them isn't eye pleasing, but it doesn't hurt to have black for a few millis on a white theme at startup.