### PR TITLE
ci: enable cache of set java

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: 11
           cache: 'gradle'
       - name: Check formatting using spotless
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: 11
           cache: 'gradle'
       - name: Build with Gradle

--- a/.github/workflows/android-debug-artifact-ondemand.yml
+++ b/.github/workflows/android-debug-artifact-ondemand.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: 11
           cache: 'gradle'
       - name: Build with Gradle

--- a/.github/workflows/android-debug-artifact-release.yml
+++ b/.github/workflows/android-debug-artifact-release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: 11
           cache: 'gradle'
       - name: Build with Gradle

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: 11
           cache: 'gradle'
       - name: Check formatting using spotless
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: 11
           cache: 'gradle'
       - name: Build with Gradle

--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: 11
           cache: 'gradle'
       - name: Check formatting using spotless
@@ -32,7 +32,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: 11
           cache: 'gradle'
       - name: Build with Gradle


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
Enable gradle cache to speed up time of ci.

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
Fixes #2586 
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [X] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [X] `./gradlew assembledebug`
- [X] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->