### PR TITLE
Switch to new ContentResolver query method for Recent files list

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,8 @@ android {
         applicationId "com.amaze.filemanager"
         minSdkVersion 14
         targetSdkVersion 30
-        versionCode 104
-        versionName "3.6.6"
+        versionCode 106
+        versionName "3.6.7"
         multiDexEnabled true
 
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <uses-feature
         android:name="android.hardware.touchscreen"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <uses-feature
         android:name="android.hardware.touchscreen"

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -20,6 +20,9 @@
 
 package com.amaze.filemanager.asynchronous.asynctasks;
 
+import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.Q;
+
 import java.io.File;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -51,10 +54,12 @@ import com.amaze.filemanager.utils.OnAsyncTaskFinished;
 import com.amaze.filemanager.utils.OnFileFound;
 import com.cloudrail.si.interfaces.CloudStorage;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Bundle;
 import android.provider.MediaStore;
 import android.text.format.Formatter;
 import android.util.Log;
@@ -517,19 +522,37 @@ public class LoadFilesListTask
     }
 
     ArrayList<LayoutElementParcelable> recentFiles = new ArrayList<>(20);
-    final String[] projection = {MediaStore.Files.FileColumns.DATA};
+    final String[] projection = {
+      MediaStore.Files.FileColumns.DATA, MediaStore.Files.FileColumns.DATE_MODIFIED
+    };
     Calendar c = Calendar.getInstance();
     c.set(Calendar.DAY_OF_YEAR, c.get(Calendar.DAY_OF_YEAR) - 2);
     Date d = c.getTime();
-    Cursor cursor =
-        context
-            .getContentResolver()
-            .query(
-                MediaStore.Files.getContentUri("external"),
-                projection,
-                null,
-                null,
-                MediaStore.Files.FileColumns.DATE_MODIFIED + " DESC LIMIT 20");
+    Cursor cursor;
+    if (SDK_INT >= Q) {
+      Bundle queryArgs = new Bundle();
+      queryArgs.putInt(ContentResolver.QUERY_ARG_LIMIT, 20);
+      queryArgs.putStringArray(
+          ContentResolver.QUERY_ARG_SORT_COLUMNS,
+          new String[] {MediaStore.Files.FileColumns.DATE_MODIFIED});
+      queryArgs.putInt(
+          ContentResolver.QUERY_ARG_SORT_DIRECTION,
+          ContentResolver.QUERY_SORT_DIRECTION_DESCENDING);
+      cursor =
+          context
+              .getContentResolver()
+              .query(MediaStore.Files.getContentUri("external"), projection, queryArgs, null);
+    } else {
+      cursor =
+          context
+              .getContentResolver()
+              .query(
+                  MediaStore.Files.getContentUri("external"),
+                  projection,
+                  null,
+                  null,
+                  MediaStore.Files.FileColumns.DATE_MODIFIED + " DESC LIMIT 20");
+    }
     if (cursor == null) return recentFiles;
     if (cursor.getCount() > 0 && cursor.moveToFirst()) {
       do {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -729,5 +729,8 @@ You only need to do this once, until the next time you select a new location for
     <string name="select_by_date">Select by date</string>
     <string name="select_similar">Select similar</string>
     <string name="error_fetching_google_play_product_list">Error fetching product list from Google Play.</string>
+    <string name="grant_all_files_permission"><html><body>Amaze needs all files permission to continue.
+        \nOn next screen, please select <b>Amaze</b> and select <b>Allow access to manage all files</b> option.
+            \n\n<font color='#ff6347'><i>Canceling this dialog will exit the app.</i></font></body></html></string>
 </resources>
 

--- a/app/src/main/res/values/translators.xml
+++ b/app/src/main/res/values/translators.xml
@@ -42,7 +42,7 @@
 	<string name="vietnamese_translation_summary" translable="false" translatable="false">ngoisaosang</string>
     <string name="japanese_translation_summary" translatable="false">Naofumi Fukue</string>
     <string name="tamil_translation_summary" translatable="false">Kuralarasi for StarsSoft</string>
-    <string name="app_version" translatable="false">v3.6.6</string>
+    <string name="app_version" translatable="false">v3.6.7</string>
     <string name="author_1" translatable="false">Arpit Khurana</string>
     <string name="author_2" translatable="false">Vishal Nehra</string>
     <string name="developer_1" translatable="false">Emmanuel Messulam</string>


### PR DESCRIPTION
## Description

Solution found at https://stackoverflow.com/a/63551176.

ContentResolver.query(Uri, String[], Bundle, CancellationSignal) was actually introduced in API 26, but just let it be - make it available only from API 30 onwards.

#### Issue tracker   
Fixes #2993

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [ ] Done  
  
#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`