### PR TITLE
fix issue #3245

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/HiddenAdapter.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/HiddenAdapter.kt
@@ -79,19 +79,24 @@ class HiddenAdapter(
             // if the user taps on the delete button, un-hide the file.
             // TODO: the "hide files" feature just hide files from view in Amaze and not create
             // .nomedia
-            val position = hiddenFiles.indexOf(file)
-            if (!file.isSmb && file.isDirectory(context)) {
-                val nomediaFile = HybridFileParcelable(
-                        hiddenFiles[position].path + "/" + FileUtils.NOMEDIA_FILE)
-                nomediaFile.mode = OpenMode.FILE
-                val filesToDelete = ArrayList<HybridFileParcelable>()
-                filesToDelete.add(nomediaFile)
-                val task = DeleteTask(context)
-                task.execute(filesToDelete)
+            thread {
+                val fragmentActivity = mainFragment.requireActivity()
+                if (!file.isSmb && file.isDirectory(context)) {
+                    val nomediaFile = HybridFileParcelable(
+                        file.path + "/" + FileUtils.NOMEDIA_FILE)
+                    nomediaFile.mode = OpenMode.FILE
+                    val filesToDelete = ArrayList<HybridFileParcelable>()
+                    filesToDelete.add(nomediaFile)
+                    val task = DeleteTask(context)
+                    task.execute(filesToDelete)
+                }
+                DataUtils.getInstance().removeHiddenFile(file.path)
+                hiddenFiles.remove(file)
+                val position = hiddenFiles.indexOf(file)
+                fragmentActivity.runOnUiThread {
+                    notifyItemRemoved(position)
+                }
             }
-            DataUtils.getInstance().removeHiddenFile(hiddenFiles[position].path)
-            hiddenFiles.remove(hiddenFiles[position])
-            notifyItemRemoved(position)
         }
         holder.row.setOnClickListener {
             // if the user taps on the hidden file, take the user there.

--- a/app/src/main/java/com/amaze/filemanager/adapters/HiddenAdapter.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/HiddenAdapter.kt
@@ -79,6 +79,7 @@ class HiddenAdapter(
             // if the user taps on the delete button, un-hide the file.
             // TODO: the "hide files" feature just hide files from view in Amaze and not create
             // .nomedia
+            val position = hiddenFiles.indexOf(file)
             if (!file.isSmb && file.isDirectory(context)) {
                 val nomediaFile = HybridFileParcelable(
                         hiddenFiles[position].path + "/" + FileUtils.NOMEDIA_FILE)

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -466,7 +466,7 @@ public class HybridFile {
 
   /**
    * Whether this object refers to a directory or file, handles all types of files
-   * Warning: Can't be used directly in UI/main thread
+   * @WorkerThread
    * @deprecated use {@link #isDirectory(Context)} to handle content resolvers
    */
   public boolean isDirectory() {

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -32,10 +32,6 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.amaze.filemanager.R;
@@ -577,7 +573,6 @@ public class HybridFile {
                 .getFolder();
         break;
       case GDRIVE:
-        // TODO : delect no meaning code
         final boolean[] isDir = new boolean[1];
         Thread googleThread = new Thread(new Runnable() {
           @Override

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -58,7 +58,6 @@ import com.amaze.filemanager.utils.OnFileFound;
 import com.amaze.filemanager.utils.SmbUtil;
 import com.amaze.filemanager.utils.Utils;
 import com.cloudrail.si.interfaces.CloudStorage;
-import com.cloudrail.si.types.CloudMetaData;
 import com.cloudrail.si.types.SpaceAllocation;
 
 import android.content.ContentResolver;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -466,7 +466,7 @@ public class HybridFile {
 
   /**
    * Whether this object refers to a directory or file, handles all types of files
-   *
+   * Warning: Can't be used directly in UI/main thread
    * @deprecated use {@link #isDirectory(Context)} to handle content resolvers
    */
   public boolean isDirectory() {
@@ -558,47 +558,13 @@ public class HybridFile {
         isDirectory = OTGUtil.getDocumentFile(path, context, false).isDirectory();
         break;
       case DROPBOX:
-        isDirectory =
-            dataUtils
-                .getAccount(OpenMode.DROPBOX)
-                .getMetadata(CloudUtil.stripPath(OpenMode.DROPBOX, path))
-                .getFolder();
-        break;
       case BOX:
-        isDirectory =
-            dataUtils
-                .getAccount(OpenMode.BOX)
-                .getMetadata(CloudUtil.stripPath(OpenMode.BOX, path))
-                .getFolder();
-        break;
       case GDRIVE:
-        final boolean[] isDir = new boolean[1];
-        Thread googleThread = new Thread(new Runnable() {
-          @Override
-          public void run() {
-            isDir[0] = dataUtils
-                            .getAccount(OpenMode.GDRIVE)
-                            .getMetadata(CloudUtil.stripPath(OpenMode.GDRIVE, path))
-                            .getFolder();
-          }
-        });
-        googleThread.start();
-        try{
-          googleThread.join();
-        }catch (InterruptedException e){
-          Log.e(TAG, "Fail to join the thread of google drive");
-        }finally {
-          isDirectory = isDir[0];
-          if (googleThread.isAlive()) {
-            googleThread.stop();
-          }
-        }
-        break;
       case ONEDRIVE:
         isDirectory =
             dataUtils
-                .getAccount(OpenMode.ONEDRIVE)
-                .getMetadata(CloudUtil.stripPath(OpenMode.ONEDRIVE, path))
+                .getAccount(mode)
+                .getMetadata(CloudUtil.stripPath(mode, path))
                 .getFolder();
         break;
       default:

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityActionMode.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityActionMode.kt
@@ -81,7 +81,6 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
             hideOption(R.id.share, menu)
             hideOption(R.id.openwith, menu)
             if (mainActivity.mReturnIntent) showOption(R.id.openmulti, menu)
-//             hideOption(R.id.setringtone,menu);
             mode.title = mainActivity.resources.getString(R.string.select)
             mainActivity
                 .updateViews(

--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityActionMode.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityActionMode.kt
@@ -81,7 +81,7 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
             hideOption(R.id.share, menu)
             hideOption(R.id.openwith, menu)
             if (mainActivity.mReturnIntent) showOption(R.id.openmulti, menu)
-            // hideOption(R.id.setringtone,menu);
+//             hideOption(R.id.setringtone,menu);
             mode.title = mainActivity.resources.getString(R.string.select)
             mainActivity
                 .updateViews(
@@ -214,7 +214,7 @@ class MainActivityActionMode(private val mainActivityReference: WeakReference<Ma
             if (mainFragmentViewModel.openMode != OpenMode.FILE) {
                 hideOption(R.id.openwith, menu)
                 hideOption(R.id.compress, menu)
-                hideOption(R.id.hide, menu)
+//                hideOption(R.id.hide, menu)
                 hideOption(R.id.addshortcut, menu)
             }
         }


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
Fixes https://github.com/TeamAmaze/AmazeFileManager/issues/3245

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
<!-- Fixes # -->
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
- Device: OPPO A33m
- OS:Android 5.1.1 - 22


#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
#### Array out of index bug fix
While I fixing this bug I found another bug in removing the hidden files. If you remove more than one file at one time, you will find the hiddenFiles array's index will get wrong. I found that the index was not updated at the time of deletion. So I added in the source code that every delete must be reindexed. If you do not add this, you will end up with an array out of bounds or removing the wrong file when you remove hidden files multiple times.