### PR TITLE
Make logback-android available runtimeOnly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -239,7 +239,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "ch.acra:acra-core:5.7.0"
     implementation 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'com.github.tony19:logback-android:2.0.0'
+    runtimeOnly "com.github.tony19:logback-android:$logbackAndroidVersion"
 }
 
 configurations.all {

--- a/app/src/main/java/com/amaze/filemanager/ui/views/appbar/SearchView.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/appbar/SearchView.java
@@ -84,7 +84,7 @@ public class SearchView {
           return false;
         });
 
-      initSearchViewColor(a);
+    initSearchViewColor(a);
     // searchViewEditText.setTextColor(Utils.getColor(this, android.R.color.black));
     // searchViewEditText.setHintTextColor(Color.parseColor(ThemedActivity.accentSkin));
   }
@@ -204,37 +204,36 @@ public class SearchView {
     return searchViewLayout.isShown();
   }
 
-    private void initSearchViewColor(MainActivity a ) {
-        AppTheme theme = a.getAppTheme().getSimpleTheme(a);
-        switch (theme) {
-            case LIGHT:
-                searchViewLayout.setBackgroundResource(R.drawable.search_view_shape);
-                searchViewEditText.setTextColor(Utils.getColor(a, android.R.color.black));
-                clearImageView.setColorFilter(ContextCompat.getColor(a, android.R.color.black),
-                        PorterDuff.Mode.SRC_ATOP);
-                backImageView.setColorFilter(ContextCompat.getColor(a, android.R.color.black),
-                        PorterDuff.Mode.SRC_ATOP);
-                break;
-            case DARK:
-            case BLACK:
-                if (theme == AppTheme.DARK){
-                    searchViewLayout.setBackgroundResource(R.drawable.search_view_shape_holo_dark);
-                }else{
-                    searchViewLayout.setBackgroundResource(R.drawable.search_view_shape_black);
-                }
-                searchViewEditText.setTextColor(Utils.getColor(a, android.R.color.white));
-                clearImageView.setColorFilter(ContextCompat.getColor(a, android.R.color.white),
-                        PorterDuff.Mode.SRC_ATOP);
-                backImageView.setColorFilter(ContextCompat.getColor(a, android.R.color.white),
-                        PorterDuff.Mode.SRC_ATOP);
-                break;
-            default:
-                break;
+  private void initSearchViewColor(MainActivity a) {
+    AppTheme theme = a.getAppTheme().getSimpleTheme(a);
+    switch (theme) {
+      case LIGHT:
+        searchViewLayout.setBackgroundResource(R.drawable.search_view_shape);
+        searchViewEditText.setTextColor(Utils.getColor(a, android.R.color.black));
+        clearImageView.setColorFilter(
+            ContextCompat.getColor(a, android.R.color.black), PorterDuff.Mode.SRC_ATOP);
+        backImageView.setColorFilter(
+            ContextCompat.getColor(a, android.R.color.black), PorterDuff.Mode.SRC_ATOP);
+        break;
+      case DARK:
+      case BLACK:
+        if (theme == AppTheme.DARK) {
+          searchViewLayout.setBackgroundResource(R.drawable.search_view_shape_holo_dark);
+        } else {
+          searchViewLayout.setBackgroundResource(R.drawable.search_view_shape_black);
         }
+        searchViewEditText.setTextColor(Utils.getColor(a, android.R.color.white));
+        clearImageView.setColorFilter(
+            ContextCompat.getColor(a, android.R.color.white), PorterDuff.Mode.SRC_ATOP);
+        backImageView.setColorFilter(
+            ContextCompat.getColor(a, android.R.color.white), PorterDuff.Mode.SRC_ATOP);
+        break;
+      default:
+        break;
     }
+  }
 
-
-    public interface SearchListener {
+  public interface SearchListener {
     void onSearch(String queue);
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ buildscript {
         commonsCompressVersion = "1.20"
         libsuVersion = "3.2.1"
         mockkVersion = "1.12.2"
+        logbackAndroidVersion = "2.0.0"
     }
     repositories {
         google()


### PR DESCRIPTION
## Description
To prevent classpath problems when running tests.
  
#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
