### PR TITLE
Lower threshold of CustomNavigationView.isNavigationViewSavedStateMissing() down to API 19

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/CustomNavigationView.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/CustomNavigationView.java
@@ -134,7 +134,7 @@ public class CustomNavigationView extends NavigationView
    * the crash see https://github.com/TeamAmaze/AmazeFileManager/issues/1101.
    */
   public boolean isNavigationViewSavedStateMissing() {
-    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
   }
 
   static class SavedState extends BaseSavedState {


### PR DESCRIPTION
## Description
Here we go again... let's see if just lower the flag can help - as seen in crash report of #3497.

#### Issue tracker   
Fixes #2284
Fixes #3497

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`