### PR TITLE
Removed url decoder in getPath

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -406,16 +406,12 @@ public class HybridFile {
   }
 
   /**
-   * Path accessor. Avoid direct access to path since path may have been URL encoded.
+   * Path accessor.
    *
-   * @return URL decoded path
+   * @return path
    */
   public String getPath() {
-    try {
-      return URLDecoder.decode(path, "UTF-8");
-    } catch (UnsupportedEncodingException ignored) {
-      return path;
-    }
+    return path;
   }
 
   public String getSimpleName() {


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
The `getPath` method performs url decoding on the stored path but url decoding is not idempotent and there is no way to distinguish between url encoded and non-url encoded string. The original code suggests the class may accept url encoded string so there might be additional things to fix.

#### Issue tracker   
Fixes #3560 

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Resizable
- OS: API Level 33

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [ ] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`