### PR TITLE
added compile_sdk, min_sdk and target_sdk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.hiya.jacoco-android'
 apply plugin: "com.starter.easylauncher"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion compile_sdk
     packagingOptions {
         resources {
             excludes += ['proguard-project.txt', 'project.properties', 'META-INF/LICENSE.txt', 'META-INF/LICENSE', 'META-INF/NOTICE.txt', 'META-INF/NOTICE', 'META-INF/DEPENDENCIES.txt', 'META-INF/DEPENDENCIES']
@@ -17,7 +17,7 @@ android {
     defaultConfig {
         applicationId "com.amaze.filemanager"
         minSdkVersion 14
-        targetSdkVersion 30
+        targetSdkVersion target_sdk
         versionCode 111
         versionName "3.8"
         multiDexEnabled true

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@
 
 buildscript {
     ext {
+        target_sdk = 30
+        compile_sdk = 31
+        min_sdk = 14
         kotlin_version = "1.5.0"
         robolectricVersion = '4.7'
         glideVersion = '4.11.0'

--- a/commons_compress_7z/build.gradle
+++ b/commons_compress_7z/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion compile_sdk
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion min_sdk
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/file_operations/build.gradle
+++ b/file_operations/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion compile_sdk
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion min_sdk
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description

#### Issue tracker   
There was 3 different Android SDKs included:
![Screenshot 2022-11-09 at 21 52 03](https://user-images.githubusercontent.com/22417494/200905400-59a66209-9ce8-41d1-9c91-54052ebef5db.png)

In gradle files, it had different versions per module, so I added it to `ext`. Now it show only one:
![Screenshot 2022-11-09 at 21 53 41](https://user-images.githubusercontent.com/22417494/200905557-a939d372-99f8-4604-b3f5-96844687065d.png)

Is there a reason to have SDK versions different for modules? at least for me having it in ext block looks cleaner, also 2 less SDK is loaded by the studio and I think it should be faster

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->