### PR TITLE
Fix wrong context used at GenericDialogCreation.showPasswordDialog() at ExtractService

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/services/ExtractService.java
@@ -388,7 +388,7 @@ public class ExtractService extends AbstractProgressiveService {
       IOException result = values[0];
       ArchivePasswordCache.getInstance().remove(compressedPath);
       GeneralDialogCreation.showPasswordDialog(
-          getApplicationContext(),
+          AppConfig.getInstance().getMainActivityContext(),
           (MainActivity) AppConfig.getInstance().getMainActivityContext(),
           AppConfig.getInstance().getUtilsProvider().getAppTheme(),
           R.string.archive_password_prompt,


### PR DESCRIPTION
#### Issue tracker   
Fixes #3649 #3531

#### Manual tests
- [x] Done  

Device:
- Pixel 2 emulator running Android 9.0
- Pixel 6 emulator running Android 13
- Galaxy Nexus emulator running Android 4.4

For above devices, extracting a password-protected archive should not crash but displays password prompt as necessary.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`