### PR TITLE
Guard against closed cursors feeded into CloudLoaderAsyncTask

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -2314,7 +2314,9 @@ public class MainActivity extends PermissionsActivity
      *
      * TODO: find a fix for repeated callbacks to onLoadFinished()
      */
-    if (cloudCursorData != null && cloudCursorData == data) return;
+    if ((cloudCursorData != null && cloudCursorData == data)
+        || data.isClosed()
+        || cloudCursorData.isClosed()) return;
     cloudCursorData = data;
 
     if (cloudLoaderAsyncTask != null


### PR DESCRIPTION
## Description
It is reported that on Samsung devices running Android 13 and OneUI 5.0 would crash on setting up cloud connections. From #3670 it was seen that `Cursor` to load keys for cloud connections was unexpectedly closed. Either it is caused by repeated calls to `MainActivity.onLoadFinished()` with closed cursors, or some unknown async behaviour that feeded CloudLoaderAsyncTask with closed `Cursor`.

Wild guess, as I wasn't able to reproduce the problem with emulators, so let's see if adding a guard against closed `Cursor`s would work.

#### Issue tracker   
Addresses #3670 

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [ ] Done  

(Because I don't have a real Android 13 device, I could only try to reproduce problem on Android 13 emulators, but failed. Pending user test)  

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`