### PR TITLE
Adds Compress option to item popup menu

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
@@ -1392,6 +1392,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
       }
     } else {
       popupMenu.getMenu().findItem(R.id.book).setVisible(false);
+      popupMenu.getMenu().findItem(R.id.compress).setVisible(true);
 
       if (description.endsWith(fileExtensionZip)
           || description.endsWith(fileExtensionJar)
@@ -1409,8 +1410,10 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
           || description.endsWith(fileExtensionGz)
           || description.endsWith(fileExtensionBzip2)
           || description.endsWith(fileExtensionLzma)
-          || description.endsWith(fileExtensionXz))
+          || description.endsWith(fileExtensionXz)) {
         popupMenu.getMenu().findItem(R.id.ex).setVisible(true);
+        popupMenu.getMenu().findItem(R.id.compress).setVisible(false);
+      }
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {

--- a/app/src/main/java/com/amaze/filemanager/ui/ItemPopupMenu.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/ItemPopupMenu.java
@@ -241,6 +241,12 @@ public class ItemPopupMenu extends PopupMenu implements PopupMenu.OnMenuItemClic
             utilitiesProvider,
             false);
         return true;
+      case R.id.compress:
+        GeneralDialogCreation.showCompressDialog(
+            mainActivity,
+            rowItem.generateBaseFile(),
+            mainActivity.getCurrentMainFragment().getMainFragmentViewModel().getCurrentPath());
+        return true;
       case R.id.return_select:
         mainFragment.returnIntentResults(rowItem.generateBaseFile());
         return true;

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -869,6 +869,15 @@ public class GeneralDialogCreation {
 
   public static void showCompressDialog(
       @NonNull final MainActivity mainActivity,
+      final HybridFileParcelable baseFile,
+      final String current) {
+    ArrayList<HybridFileParcelable> baseFiles = new ArrayList<>();
+    baseFiles.add(baseFile);
+    showCompressDialog(mainActivity, baseFiles, current);
+  }
+
+  public static void showCompressDialog(
+      @NonNull final MainActivity mainActivity,
       final ArrayList<HybridFileParcelable> baseFiles,
       final String current) {
     int accentColor = mainActivity.getAccent();

--- a/app/src/main/res/menu/item_extras.xml
+++ b/app/src/main/res/menu/item_extras.xml
@@ -40,6 +40,9 @@
         android:id="@+id/about"
         android:title="@string/properties"/>
     <item
+        android:id="@+id/compress"
+        android:title="@string/compress" />
+    <item
         android:id="@+id/share"
         android:title="@string/share" />
     <item


### PR DESCRIPTION
## Description
Allow compress single folder/file by just tapping on the item's individual context menu.

#### Issue tracker   
Fixes #3766

#### Manual tests
- [x] Done  
  
- Device: Fairphone 3
- OS: LineageOS 19.1 (12)

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`