### PR TITLE
Upgrade Kotlin to 1.9.10

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.hiya.jacoco-android'
 apply plugin: "com.starter.easylauncher"
 
 android {
-    compileSdkVersion 31
+    compileSdk 31
     packagingOptions {
         resources {
             excludes += ['proguard-project.txt', 'project.properties', 'META-INF/LICENSE.txt', 'META-INF/LICENSE', 'META-INF/NOTICE.txt', 'META-INF/NOTICE', 'META-INF/DEPENDENCIES.txt', 'META-INF/DEPENDENCIES']
@@ -91,7 +91,6 @@ android {
 
     kotlinOptions {
         jvmTarget = '1.8'
-        useIR = true
     }
 
     testOptions {

--- a/app/src/main/java/com/amaze/filemanager/ui/base/BaseBottomSheetFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/base/BaseBottomSheetFragment.kt
@@ -23,6 +23,7 @@ package com.amaze.filemanager.ui.base
 import android.app.Dialog
 import android.os.Bundle
 import android.view.View
+import androidx.core.content.res.ResourcesCompat
 import com.amaze.filemanager.R
 import com.amaze.filemanager.ui.activities.superclasses.ThemedActivity
 import com.amaze.filemanager.ui.theme.AppTheme
@@ -39,28 +40,33 @@ open class BaseBottomSheetFragment : BottomSheetDialogFragment() {
      * Initializes bottom sheet ui resources based on current theme
      */
     fun initDialogResources(rootView: View) {
-        when ((activity as ThemedActivity?)!!.appTheme!!) {
-            AppTheme.DARK -> {
-                rootView.setBackgroundDrawable(
-                    context?.resources?.getDrawable(
-                        R.drawable.shape_dialog_bottomsheet_dark
+        (requireActivity() as ThemedActivity).appTheme?.let { appTheme ->
+            when (appTheme) {
+                AppTheme.DARK -> {
+                    rootView.background = ResourcesCompat.getDrawable(
+                        requireContext().resources,
+                        R.drawable.shape_dialog_bottomsheet_dark,
+                        requireActivity().theme
                     )
-                )
-            }
-            AppTheme.BLACK -> {
-                rootView.setBackgroundDrawable(
-                    context?.resources?.getDrawable(
-                        R.drawable.shape_dialog_bottomsheet_black
+                }
+                AppTheme.BLACK -> {
+                    rootView.background = ResourcesCompat.getDrawable(
+                        requireContext().resources,
+                        R.drawable.shape_dialog_bottomsheet_black,
+                        requireActivity().theme
                     )
-                )
-            }
-            AppTheme.LIGHT, AppTheme.TIMED -> {
-                rootView
-                    .setBackgroundDrawable(
-                        context?.resources?.getDrawable(
-                            R.drawable.shape_dialog_bottomsheet_white
-                        )
+                }
+                AppTheme.LIGHT, AppTheme.TIMED -> {
+                    rootView.background = ResourcesCompat.getDrawable(
+                        requireContext().resources,
+                        R.drawable.shape_dialog_bottomsheet_white,
+                        requireActivity().theme
                     )
+                }
+                AppTheme.SYSTEM -> {
+                    // do nothing
+                    // FIXME: or need to derive the necessary background based on app's accent?
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        kotlin_version = "1.6.10"
+        kotlin_version = "1.9.10"
         robolectricVersion = '4.9'
         glideVersion = '4.11.0'
         sshjVersion = '0.35.0'

--- a/commons_compress_7z/build.gradle
+++ b/commons_compress_7z/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdk 31
 
     defaultConfig {
         minSdkVersion 19

--- a/file_operations/build.gradle
+++ b/file_operations/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdk 31
 
     defaultConfig {
         minSdkVersion 19
@@ -51,7 +51,7 @@ android {
     }
 
     kotlinOptions {
-        useIR = true
+        jvmTarget = '1.8'
     }
 }
 


### PR DESCRIPTION
## Description
As title; with some deprecation at `build.gradle` removed.

Also fixes code problem at `BaseBottomSheetFragment` causing project compile fails - where a `when` branch for `SYSTEM` theme is missing.

There is no handling for `SYSTEM` theme at `ThemedActivity`, hence the do-nothing branch as `BaseBottomSheetFragment` too.

#### Manual tests
- [ ] Done  
  
#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`