### PR TITLE
Fix broken OTGUtil.getDocumentFile()

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -46,8 +46,8 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/GeneralDialogCreation.java
@@ -441,7 +441,7 @@ public class GeneralDialogCreation {
         new MaterialDialog.Builder(context)
             .title(context.getString(R.string.restore_files))
             .customView(dialogView, true)
-            .theme(appTheme.getMaterialDialogTheme(context))
+            .theme(appTheme.getMaterialDialogTheme())
             .negativeText(context.getString(R.string.cancel).toUpperCase())
             .positiveText(context.getString(R.string.done).toUpperCase())
             .positiveColor(accentColor)

--- a/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/OTGUtil.kt
@@ -171,7 +171,9 @@ object OTGUtil {
         var retval: DocumentFile? = DocumentFile.fromTreeUri(context, rootUri)
             ?: throw DocumentFileNotFoundException(rootUri, path)
         val parts: Array<String> = if (openMode == OpenMode.DOCUMENT_FILE) {
-            path.substringAfter(URLDecoder.decode(rootUri.toString(), Charsets.UTF_8.name()))
+            URLDecoder.decode(path, Charsets.UTF_8.name()).substringAfter(
+                URLDecoder.decode(rootUri.toString(), Charsets.UTF_8.name())
+            )
                 .split("/", PATH_SEPARATOR_ENCODED).toTypedArray()
         } else {
             path.split("/").toTypedArray()


### PR DESCRIPTION
## Description

Addresses #4038, that under specific root URI the file/folders should be able to be found correctly.

Previously the code is looking for file by splitting parts of a non-decoded URI against a decoded URI root, e.g.

```
root URI = content://com.android.externalstorage.documents/tree/primary:Android/data/com.poobslag.turbofat/files
looking file path = content://com.android.externalstorage.documents/tree/primary%3AAndroid%2Fdata%2Fcom.poobslag.turbofat/files
```

which would most likely fail. This PR fixes it by also decoding the path it is looking for.

#### Issue tracker   
Addresses #4038, as there is still yet to find the way to manipulate the URI root - current implementation of `Android/data` access is by package, which would still work on Android 13.

#### Manual tests
- [ ] Done  
  
- Device: Pixel 5 emulator
- OS: Android 11

Delete a directory under a certain package in Android/data would work.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`