### PR TITLE
Discard dependency info in apk and stricten cleartext traffic to local streamer only

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,13 @@ android {
         }
     }
 
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
+
     sourceSets {
         test.java.srcDirs += '../testShared/src/test/java'
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,7 +57,7 @@
         android:requestLegacyExternalStorage="true"
         android:banner="@drawable/about_header"
         android:localeConfig="@xml/locales_config"
-        android:usesCleartextTraffic="true">
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <activity
             android:exported="true"

--- a/app/src/main/java/com/amaze/filemanager/utils/ContextLocaleExt.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/ContextLocaleExt.kt
@@ -21,6 +21,8 @@
 package com.amaze.filemanager.utils
 
 import android.content.Context
+import android.os.Build
+import android.os.Build.VERSION_CODES.N
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import com.amaze.filemanager.R
@@ -48,6 +50,12 @@ fun Context.getLocaleListFromXml(): LocaleListCompat {
         e.printStackTrace()
     } catch (e: IOException) {
         e.printStackTrace()
+    }
+
+    // Remove locale tags that would produce same locale on Android N or above
+    if (Build.VERSION.SDK_INT >= N) {
+        tagsList.remove("id")
+        tagsList.remove("he")
     }
 
     return LocaleListCompat.forLanguageTags(tagsList.joinToString(","))

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>

--- a/app/src/test/java/com/amaze/filemanager/ui/fragments/preferencefragments/UiPrefsFragmentTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/fragments/preferencefragments/UiPrefsFragmentTest.kt
@@ -51,7 +51,12 @@ import kotlin.random.Random
  * Tests for [UiPrefsFragment].
  */
 @Config(
-    sdk = [Build.VERSION_CODES.KITKAT, Build.VERSION_CODES.P, Build.VERSION_CODES.R],
+    sdk = [
+        Build.VERSION_CODES.KITKAT,
+        Build.VERSION_CODES.N,
+        Build.VERSION_CODES.P,
+        Build.VERSION_CODES.R
+    ],
     shadows = [
         ShadowMultiDex::class,
         ShadowStorageManager::class,


### PR DESCRIPTION
## Description

- Allow cleartext traffic only at localhost, which is required for streaming media over network
- Disable include dependency info in built apk. Not much advantage from this, and Google would encrypt it using its own method, hence remove it altogether

#### Issue tracker   
Fixes #4084
Fixes #4088

#### Manual tests
- [x] Done  

- Pixel 2 emulator, running Android 7.1.1
- Pixel 6 emulator, running Android 13

Streaming media from remote server should continue work without problem.

APK proprietary blob existence check, may rely on @IzzySoft's help instead

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
