### PR TITLE
Bump kotlin, sshj, jcifs-ng and Bouncy Castle dependencies + migrate to libs.versions.toml

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,10 +4,11 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'com.hiya.jacoco-android'
 apply plugin: "com.starter.easylauncher"
+apply plugin: 'com.google.devtools.ksp'
 
 android {
     namespace "com.amaze.filemanager"
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
     packagingOptions {
         resources {
             excludes += ['proguard-project.txt', 'project.properties', 'META-INF/LICENSE.txt', 'META-INF/LICENSE', 'META-INF/NOTICE.txt', 'META-INF/NOTICE', 'META-INF/DEPENDENCIES.txt', 'META-INF/DEPENDENCIES']
@@ -17,8 +18,8 @@ android {
 
     defaultConfig {
         applicationId "com.amaze.filemanager"
-        minSdkVersion 19
-        targetSdkVersion 33
+        minSdkVersion libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
         versionCode 121
         versionName "3.10"
         multiDexEnabled true
@@ -49,6 +50,7 @@ android {
             buildConfigField "String", "CRYPTO_IV", "\"LxbHiJhhUXcj\""
             buildConfigField "String", "FTP_SERVER_KEYSTORE_PASSWORD", "\"vishal007\""
             debuggable true //For "debug" banner on icon
+            enableUnitTestCoverage true
         }
 
         release {
@@ -63,6 +65,7 @@ android {
 
     buildFeatures {
         viewBinding true
+        buildConfig true
     }
 
     flavorDimensions = ['static']
@@ -119,148 +122,135 @@ dependencies {
         module("org.bouncycastle:bcpkix-jdk15to18") {
             replacedBy("org.bouncycastle:bcpkix-jdk18on")
         }
-
     }
 
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.readystatesoftware.systembartint:systembartint:1.0.3'
+    implementation libs.systembarTint
 
-    implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
-    implementation 'androidx.legacy:legacy-support-v13:1.0.0'
-    implementation "com.google.android.material:material:$androidMaterialVersion"
-    implementation "androidx.fragment:fragment-ktx:$androidXFragmentVersion"
-    implementation "androidx.appcompat:appcompat:$androidXAppCompatVersion"
-    implementation 'androidx.palette:palette-ktx:1.0.0'
-    implementation 'androidx.cardview:cardview:1.0.0'
-    implementation "androidx.room:room-runtime:$roomVersion"
-    playImplementation "com.android.billingclient:billing:$androidBillingVersion"
-    kapt "androidx.room:room-compiler:$roomVersion"
-    // RxJava support for Room
-    implementation "androidx.room:room-rxjava2:$roomVersion"
-    kapt "androidx.annotation:annotation:$androidXAnnotationVersion"
+    implementation libs.androidX.vectordrawable.animated
+    implementation libs.androidX.legacySupportV13
+    implementation libs.androidX.material
+    implementation libs.androidX.fragment
+    implementation libs.androidX.appcompat
+    implementation libs.androidX.preference
+    implementation libs.androidX.core
+    implementation libs.androidX.palette
+    implementation libs.androidX.cardview
+    implementation libs.androidX.constraintLayout
+    implementation libs.androidx.multidex //Multiple dex files
+    implementation libs.room.runtime
+    implementation libs.room.rxjava2
 
-    implementation "androidx.preference:preference-ktx:$androidXPrefVersion"
+    ksp libs.room.compiler
+    ksp libs.androidX.annotation
 
     //For tests
-    testImplementation "junit:junit:$junitVersion"//tests the app logic
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"//tests android interaction
-    testImplementation "org.robolectric:shadows-httpclient:$robolectricVersion"//tests android interaction
-    testImplementation "androidx.test:core:$androidXTestVersion"
-    testImplementation "androidx.test:runner:$androidXTestRunnerVersion"
-    testImplementation "androidx.test:rules:$androidXTestVersion"
-    testImplementation "androidx.test.ext:junit:$androidXTestExtVersion"
-    testImplementation "androidx.fragment:fragment-testing:$androidXFragmentVersion"
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
-    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
-    testImplementation "org.apache.sshd:sshd-core:1.7.0"
-    testImplementation "org.awaitility:awaitility:$awaitilityVersion"
-    testImplementation "org.jsoup:jsoup:$jsoupVersion"
-    testImplementation "androidx.room:room-migration:$roomVersion"
-    testImplementation "io.mockk:mockk:$mockkVersion"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinxCoroutineTestVersion"
-    testImplementation "androidx.arch.core:core-testing:$androidXArchCoreTestVersion"
-    kaptTest "com.google.auto.service:auto-service:1.0-rc4"
+    testImplementation libs.junit//tests the app logic
+    testImplementation libs.robolectric//tests android interaction
+    testImplementation libs.robolectric.shadows.httpclient//tests android interaction
+    testImplementation libs.androidX.test.core
+    testImplementation libs.androidX.test.runner
+    testImplementation libs.androidX.test.rules
+    testImplementation libs.androidX.test.ext.junit
+    testImplementation libs.androidX.fragment.testing
+    testImplementation libs.mockito.core
+    testImplementation libs.mockito.inline
+    testImplementation libs.mockito.kotlin
+    testImplementation libs.apache.sshd
+    testImplementation libs.awaitility
+    testImplementation libs.jsoup
+    testImplementation libs.room.migration
+    testImplementation libs.mockk
+    testImplementation libs.kotlin.coroutine.test
+    testImplementation libs.androidX.core.testing
+    kspTest libs.auto.service
 
-    androidTestImplementation "junit:junit:$junitVersion"//tests the app logic
-    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
-    androidTestImplementation "androidx.test:core:$androidXTestVersion"
-    androidTestImplementation "androidx.test:runner:$androidXTestVersion"
-    androidTestImplementation "androidx.test:rules:$androidXTestVersion"
-    androidTestImplementation "androidx.test.ext:junit:$androidXTestExtVersion"
-    androidTestImplementation "androidx.test.uiautomator:uiautomator:$uiAutomatorVersion"
-    androidTestImplementation "androidx.fragment:fragment-testing:$androidXFragmentVersion"
-    androidTestImplementation "commons-net:commons-net:$commonsNetVersion"
-    androidTestImplementation "org.awaitility:awaitility:$awaitilityVersion"
+    androidTestImplementation libs.junit //tests the app logic
+    androidTestImplementation libs.androidX.test.expresso
+    androidTestImplementation libs.androidX.test.core
+    androidTestImplementation libs.androidX.test.runner
+    androidTestImplementation libs.androidX.test.rules
+    androidTestImplementation libs.androidX.test.ext.junit
+    androidTestImplementation libs.androidX.test.uiautomator
+    androidTestImplementation libs.androidX.fragment.testing
+    androidTestImplementation libs.commons.net
+    androidTestImplementation libs.awaitility
 
     //Detect memory leaks
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.7'
+    debugImplementation libs.leakcanary.android
 
-    implementation "org.apache.commons:commons-compress:$commonsCompressVersion"
+    implementation libs.commons.compress
 
-    playImplementation "com.github.junrar:junrar:$junrarVersion"
+    implementation libs.materialdialogs.core
+    implementation libs.materialdialogs.commons
 
-    implementation "com.afollestad.material-dialogs:core:$materialDialogsVersion"
-    implementation "com.afollestad.material-dialogs:commons:$materialDialogsVersion"
+    implementation libs.apache.mina.core
+    implementation libs.apache.ftpserver.ftplet.api
+    implementation libs.apache.ftpserver.core
 
-    // https://mvnrepository.com/artifact/org.apache.mina/mina-core
-    implementation group: 'org.apache.mina', name: 'mina-core', version: '2.0.16'
+    implementation libs.eventbus
 
-    //implementation files('libs/ftplet-api-1.1.0-SNAPSHOT.jar')
-    // https://mvnrepository.com/artifact/org.apache.ftpserver/ftplet-api
-    implementation "org.apache.ftpserver:ftplet-api:$ftpserverVersion"
+    implementation libs.libsu.core
+    implementation libs.libsu.io
 
-    //implementation files('libs/ftpserver-core-1.1.0-SNAPSHOT.jar')
-    // https://mvnrepository.com/artifact/org.apache.ftpserver/ftpserver-core
-    implementation "org.apache.ftpserver:ftpserver-core:$ftpserverVersion"
+    playImplementation libs.cloudrail.si.android
+    playImplementation libs.junrar
+    playImplementation libs.google.play.billing
 
-    implementation 'org.greenrobot:eventbus:3.3.1'
+    implementation libs.mpAndroidChart//Nice charts and graphs
 
-    implementation "com.github.topjohnwu.libsu:core:${libsuVersion}"
-    implementation "com.github.topjohnwu.libsu:io:${libsuVersion}"
-
-    playImplementation 'com.cloudrail:cloudrail-si-android:2.22.4'
-
-    implementation 'com.github.PhilJay:MPAndroidChart:v3.0.2'//Nice charts and graphs
-
-    implementation 'com.github.npgall:concurrent-trees:2.6.1'//Concurrent tries
+    implementation libs.concurrent.trees//Concurrent tries
 
     //SFTP
-    implementation "com.hierynomus:sshj:$sshjVersion"
-
+    implementation libs.sshj
     //smb
-    implementation "eu.agno3.jcifs:jcifs-ng:$jcifsVersion"
-
+    implementation libs.jcifs.ng
     //FTP
-    implementation "commons-net:commons-net:$commonsNetVersion"
-
+    implementation libs.commons.net
     //OkHttp
-    implementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
+    implementation libs.okhttp
 
-    implementation "org.bouncycastle:bcpkix-jdk18on:$bouncyCastleVersion"
-    implementation "org.bouncycastle:bcprov-jdk18on:$bouncyCastleVersion"
+    implementation libs.bcpkix.jdk18on
+    implementation libs.bcprov.jdk18on
 
     //Glide: loads icons seemlessly
-    implementation "com.github.bumptech.glide:glide:$glideVersion"
-    implementation ("com.github.bumptech.glide:recyclerview-integration:$glideVersion") {
+    implementation libs.glide
+    implementation (libs.glide.recyclerView) {
         // Excludes the support library because it's already included by Glide.
         transitive = false
     }
-    kapt "com.github.bumptech.glide:compiler:$glideVersion"
+    ksp libs.glide.ksp
 
-    implementation "com.leinardi.android:speed-dial:$fabSpeedDialVersion"
+    implementation libs.speedDial
 
     //Simple library show
-    implementation('com.mikepenz:aboutlibraries:6.1.1@aar') {
+    implementation(libs.aboutLibraries) {
         transitive = true
     }
 
-    implementation 'androidx.multidex:multidex:2.0.1'//Multiple dex files
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-
     //zip4j: support password-protected zips
-    implementation "net.lingala.zip4j:zip4j:$zip4jVersion"
+    implementation libs.zip4j
 
-    implementation 'org.tukaani:xz:1.9'
+    implementation libs.xz
 
-    implementation "io.reactivex.rxjava2:rxandroid:$rxAndroidVersion"
+    implementation libs.rxandroid
     // Because RxAndroid releases are few and far between, it is recommended you also
     // explicitly depend on RxJava's latest version for bug fixes and new features.
     // (see https://github.com/ReactiveX/RxJava/releases for latest 3.x.x version)
-    implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
+    implementation libs.rxjava
 
     implementation project(':commons_compress_7z')
     implementation project(':file_operations')
     implementation project(':portscanner')
-    implementation "androidx.core:core-ktx:$androidXCoreVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "ch.acra:acra-core:5.7.0"
-    implementation 'org.slf4j:slf4j-api:2.0.7'
-    implementation "com.github.tony19:logback-android:$logbackAndroidVersion"
-    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
 
-    implementation 'com.google.code.gson:gson:2.9.1'
-    implementation 'com.github.TeamAmaze:AmazeTrashBin:1.0.10'
+    implementation libs.kotlin.stdlib.jdk8
+    implementation libs.acra.core
+    implementation libs.slf4j.api
+    implementation libs.logback.android
+    testImplementation libs.logback.classic
+
+    implementation libs.gson
+    implementation libs.amaze.trashBin
 }
 
 kotlin {
@@ -303,12 +293,15 @@ clean.dependsOn supportOldLangCodes
 clean.mustRunAfter supportOldLangCodes
 
 jacoco {
-    toolVersion = "${jacocoVersion}"
+    toolVersion = libs.versions.jacoco.get()
 }
 
-jacocoAndroidUnitTestReport {
-    html.enabled true
-    xml.enabled true
+tasks.withType(JacocoReport).configureEach {
+    reports {
+        csv.required.set(false)
+        html.required.set(true)
+        xml.required.set(true)
+    }
 }
 
 tasks.withType(Test).configureEach {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,12 +107,19 @@ android {
 dependencies {
 
     modules {
+        module("org.bouncycastle:bcprov-jdk15on") {
+            replacedBy("org.bouncycastle:bcprov-jdk18on")
+        }
+        module("org.bouncycastle:bcpkix-jdk15on") {
+            replacedBy("org.bouncycastle:bcpkix-jdk18on")
+        }
         module("org.bouncycastle:bcprov-jdk15to18") {
-            replacedBy("org.bouncycastle:bcprov-jdk15on")
+            replacedBy("org.bouncycastle:bcprov-jdk18on")
         }
         module("org.bouncycastle:bcpkix-jdk15to18") {
-            replacedBy("org.bouncycastle:bcpkix-jdk15on")
+            replacedBy("org.bouncycastle:bcpkix-jdk18on")
         }
+
     }
 
     implementation fileTree(include: ['*.jar'], dir: 'libs')
@@ -210,8 +217,8 @@ dependencies {
     //OkHttp
     implementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
 
-    implementation "org.bouncycastle:bcpkix-jdk15on:$bouncyCastleVersion"
-    implementation "org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion"
+    implementation "org.bouncycastle:bcpkix-jdk18on:$bouncyCastleVersion"
+    implementation "org.bouncycastle:bcprov-jdk18on:$bouncyCastleVersion"
 
     //Glide: loads icons seemlessly
     implementation "com.github.bumptech.glide:glide:$glideVersion"

--- a/app/src/androidTest/java/com/amaze/filemanager/utils/CryptUtilEspressoTest.kt
+++ b/app/src/androidTest/java/com/amaze/filemanager/utils/CryptUtilEspressoTest.kt
@@ -91,7 +91,7 @@ class CryptUtilEspressoTest {
         CryptUtil(
             AppConfig.getInstance(),
             HybridFileParcelable(targetFile.absolutePath).also {
-                it.size = targetFile.length()
+                it.setSize(targetFile.length())
             },
             Environment.getExternalStorageDirectory().absolutePath,
             ProgressHandler(),
@@ -134,7 +134,7 @@ class CryptUtilEspressoTest {
         CryptUtil(
             AppConfig.getInstance(),
             HybridFileParcelable(targetFile.absolutePath).also {
-                it.size = targetFile.length()
+                it.setSize(targetFile.length())
             },
             Environment.getExternalStorageDirectory().absolutePath,
             ProgressHandler(),

--- a/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/CompressedExplorerAdapter.java
@@ -23,7 +23,6 @@ package com.amaze.filemanager.adapters;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.amaze.filemanager.GlideApp;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.adapters.data.CompressedObjectParcelable;
 import com.amaze.filemanager.adapters.holders.CompressedItemViewHolder;
@@ -39,6 +38,7 @@ import com.amaze.filemanager.ui.theme.AppTheme;
 import com.amaze.filemanager.ui.views.CircleGradientDrawable;
 import com.amaze.filemanager.utils.AnimUtils;
 import com.amaze.filemanager.utils.Utils;
+import com.bumptech.glide.Glide;
 
 import android.app.Activity;
 import android.content.Context;
@@ -240,7 +240,7 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
               compressedExplorerFragment.getResources().getDisplayMetrics()));
 
     if (rowItem.type == CompressedObjectParcelable.TYPE_GOBACK) {
-      GlideApp.with(compressedExplorerFragment)
+      Glide.with(compressedExplorerFragment)
           .load(R.drawable.ic_arrow_left_white_24dp)
           .into(holder.genericIcon);
       gradientDrawable.setColor(Utils.getColor(context, R.color.goback_item));
@@ -248,9 +248,7 @@ public class CompressedExplorerAdapter extends RecyclerView.Adapter<CompressedIt
       holder.txtDesc.setText("");
       holder.date.setText(R.string.goback);
     } else {
-      GlideApp.with(compressedExplorerFragment)
-          .load(rowItem.iconData.image)
-          .into(holder.genericIcon);
+      Glide.with(compressedExplorerFragment).load(rowItem.iconData.image).into(holder.genericIcon);
 
       if (compressedExplorerFragment.showLastModified)
         holder.date.setText(Utils.getDate(context, rowItem.date));

--- a/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/RecyclerAdapter.java
@@ -38,7 +38,6 @@ import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.amaze.filemanager.GlideApp;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.adapters.data.IconDataParcelable;
 import com.amaze.filemanager.adapters.data.LayoutElementParcelable;
@@ -69,6 +68,7 @@ import com.amaze.filemanager.utils.AnimUtils;
 import com.amaze.filemanager.utils.GlideConstants;
 import com.amaze.filemanager.utils.MainActivityActionMode;
 import com.amaze.filemanager.utils.Utils;
+import com.bumptech.glide.Glide;
 import com.bumptech.glide.integration.recyclerview.RecyclerViewPreloader;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.GlideException;
@@ -616,7 +616,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
     preloader =
         new RecyclerViewPreloader<>(
-            GlideApp.with(mainFragment),
+            Glide.with(mainFragment),
             modelProvider,
             sizeProvider,
             GlideConstants.MAX_PRELOAD_FILES);
@@ -807,10 +807,10 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         });
 
     // clear previously cached icon
-    GlideApp.with(mainFragment).clear(holder.genericIcon);
-    GlideApp.with(mainFragment).clear(holder.pictureIcon);
-    GlideApp.with(mainFragment).clear(holder.apkIcon);
-    GlideApp.with(mainFragment).clear(holder.baseItemView);
+    Glide.with(mainFragment).clear(holder.genericIcon);
+    Glide.with(mainFragment).clear(holder.pictureIcon);
+    Glide.with(mainFragment).clear(holder.apkIcon);
+    Glide.with(mainFragment).clear(holder.baseItemView);
 
     holder.baseItemView.setOnClickListener(
         v -> {
@@ -1023,10 +1023,10 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
     // view is a grid view
     // clear previously cached icon
-    GlideApp.with(mainFragment).clear(holder.genericIcon);
-    GlideApp.with(mainFragment).clear(holder.iconLayout);
-    GlideApp.with(mainFragment).clear(holder.imageView1);
-    GlideApp.with(mainFragment).clear(holder.baseItemView);
+    Glide.with(mainFragment).clear(holder.genericIcon);
+    Glide.with(mainFragment).clear(holder.iconLayout);
+    Glide.with(mainFragment).clear(holder.imageView1);
+    Glide.with(mainFragment).clear(holder.baseItemView);
 
     holder.checkImageViewGrid.setColorFilter(accentColor);
     holder.baseItemView.setOnClickListener(
@@ -1061,7 +1061,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         holder.genericIcon.setImageResource(R.drawable.ic_doc_apk_white);
       }
     } else {
-      GlideApp.with(mainFragment).load(rowItem.iconData.image).into(holder.genericIcon);
+      Glide.with(mainFragment).load(rowItem.iconData.image).into(holder.genericIcon);
     }
 
     if (holder.genericIcon.getVisibility() == View.VISIBLE) {
@@ -1275,7 +1275,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
       OnImageProcessed errorListener) {
     if (iconData.isImageBroken()) {
       viewHolder.genericIcon.setVisibility(View.VISIBLE);
-      GlideApp.with(mainFragment)
+      Glide.with(mainFragment)
           .load(R.drawable.ic_broken_image_white_24dp)
           .into(viewHolder.genericIcon);
       GradientDrawable gradientDrawable = (GradientDrawable) viewHolder.genericIcon.getBackground();
@@ -1286,7 +1286,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     }
 
     viewHolder.genericIcon.setVisibility(View.VISIBLE);
-    GlideApp.with(mainFragment).load(iconData.loadingImage).into(viewHolder.genericIcon);
+    Glide.with(mainFragment).load(iconData.loadingImage).into(viewHolder.genericIcon);
     GradientDrawable gradientDrawable = (GradientDrawable) viewHolder.genericIcon.getBackground();
 
     RequestListener<Drawable> requestListener =
@@ -1298,7 +1298,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             new Handler(
                     msg -> {
                       viewHolder.genericIcon.setVisibility(View.VISIBLE);
-                      GlideApp.with(mainFragment)
+                      Glide.with(mainFragment)
                           .load(R.drawable.ic_broken_image_white_24dp)
                           .into(viewHolder.genericIcon);
                       return false;
@@ -1344,7 +1344,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
       viewHolder.genericIcon.setVisibility(View.VISIBLE);
       iconBackground.setBackgroundColor(grey_color);
-      GlideApp.with(mainFragment)
+      Glide.with(mainFragment)
           .load(R.drawable.ic_broken_image_white_24dp)
           .into(viewHolder.genericIcon);
       view.setVisibility(View.INVISIBLE);
@@ -1357,7 +1357,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         getBoolean(PREFERENCE_USE_CIRCULAR_IMAGES) ? viewHolder.genericIcon : viewHolder.iconLayout;
 
     viewHolder.genericIcon.setVisibility(View.VISIBLE);
-    GlideApp.with(mainFragment).load(iconData.loadingImage).into(viewHolder.genericIcon);
+    Glide.with(mainFragment).load(iconData.loadingImage).into(viewHolder.genericIcon);
     view.setVisibility(View.INVISIBLE);
 
     RequestListener<Drawable> requestListener =
@@ -1368,7 +1368,7 @@ public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             iconBackground.setBackgroundColor(grey_color);
             new Handler(
                     msg -> {
-                      GlideApp.with(mainFragment)
+                      Glide.with(mainFragment)
                           .load(R.drawable.ic_broken_image_white_24dp)
                           .into(viewHolder.genericIcon);
                       return false;

--- a/app/src/main/java/com/amaze/filemanager/adapters/glide/AppsAdapterPreloadModel.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/glide/AppsAdapterPreloadModel.java
@@ -27,9 +27,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.amaze.filemanager.GlideApp;
-import com.amaze.filemanager.GlideRequest;
 import com.amaze.filemanager.R;
+import com.bumptech.glide.Glide;
 import com.bumptech.glide.ListPreloader;
 import com.bumptech.glide.RequestBuilder;
 
@@ -51,12 +50,12 @@ public class AppsAdapterPreloadModel implements ListPreloader.PreloadModelProvid
   private final Logger LOG = LoggerFactory.getLogger(AppsAdapterPreloadModel.class);
 
   private Context mContext;
-  private GlideRequest<Drawable> request;
+  private RequestBuilder<Drawable> request;
   private List<String> items;
   private boolean isBottomSheet;
 
   public AppsAdapterPreloadModel(Fragment f, boolean isBottomSheet) {
-    request = GlideApp.with(f).asDrawable().fitCenter();
+    request = Glide.with(f).asDrawable().fitCenter();
     this.mContext = f.requireContext();
     this.isBottomSheet = isBottomSheet;
   }

--- a/app/src/main/java/com/amaze/filemanager/adapters/glide/RecyclerPreloadModelProvider.java
+++ b/app/src/main/java/com/amaze/filemanager/adapters/glide/RecyclerPreloadModelProvider.java
@@ -23,9 +23,8 @@ package com.amaze.filemanager.adapters.glide;
 import java.util.Collections;
 import java.util.List;
 
-import com.amaze.filemanager.GlideApp;
-import com.amaze.filemanager.GlideRequest;
 import com.amaze.filemanager.adapters.data.IconDataParcelable;
+import com.bumptech.glide.Glide;
 import com.bumptech.glide.ListPreloader;
 import com.bumptech.glide.RequestBuilder;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
@@ -43,12 +42,12 @@ public class RecyclerPreloadModelProvider
     implements ListPreloader.PreloadModelProvider<IconDataParcelable> {
 
   private final List<IconDataParcelable> urisToLoad;
-  private final GlideRequest<Drawable> request;
+  private final RequestBuilder<Drawable> request;
 
   public RecyclerPreloadModelProvider(
       @NonNull Fragment fragment, @NonNull List<IconDataParcelable> uris, boolean isCircled) {
     urisToLoad = uris;
-    GlideRequest<Drawable> incompleteRequest = GlideApp.with(fragment).asDrawable();
+    RequestBuilder<Drawable> incompleteRequest = Glide.with(fragment).asDrawable();
 
     if (isCircled) {
       request = incompleteRequest.circleCrop();

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/OpenFileDialogFragment.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/OpenFileDialogFragment.kt
@@ -34,7 +34,6 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.amaze.filemanager.GlideApp
 import com.amaze.filemanager.R
 import com.amaze.filemanager.adapters.AppsRecyclerAdapter
 import com.amaze.filemanager.adapters.data.AppDataParcelable
@@ -55,6 +54,7 @@ import com.amaze.filemanager.ui.provider.UtilitiesProvider
 import com.amaze.filemanager.ui.startActivityCatchingSecurityException
 import com.amaze.filemanager.ui.views.ThemedTextView
 import com.amaze.filemanager.utils.GlideConstants
+import com.bumptech.glide.Glide
 import com.bumptech.glide.integration.recyclerview.RecyclerViewPreloader
 import com.bumptech.glide.util.ViewPreloadSizeProvider
 import org.slf4j.Logger
@@ -311,7 +311,7 @@ class OpenFileDialogFragment : BaseBottomSheetFragment(), AdjustListViewForTv<Ap
         val modelProvider = AppsAdapterPreloadModel(this, true)
         val sizeProvider = ViewPreloadSizeProvider<String>()
         var preloader = RecyclerViewPreloader(
-            GlideApp.with(this),
+            Glide.with(this),
             modelProvider,
             sizeProvider,
             GlideConstants.MAX_PRELOAD_FILES

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/AppsListFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/AppsListFragment.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Objects;
 
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.amaze.filemanager.GlideApp;
 import com.amaze.filemanager.R;
 import com.amaze.filemanager.adapters.AppsRecyclerAdapter;
 import com.amaze.filemanager.adapters.data.AppDataParcelable;
@@ -43,6 +42,7 @@ import com.amaze.filemanager.ui.theme.AppTheme;
 import com.amaze.filemanager.ui.views.FastScroller;
 import com.amaze.filemanager.utils.GlideConstants;
 import com.amaze.filemanager.utils.Utils;
+import com.bumptech.glide.Glide;
 import com.bumptech.glide.integration.recyclerview.RecyclerViewPreloader;
 import com.bumptech.glide.util.ViewPreloadSizeProvider;
 
@@ -113,10 +113,7 @@ public class AppsListFragment extends Fragment
     ViewPreloadSizeProvider<String> sizeProvider = new ViewPreloadSizeProvider<>();
     preloader =
         new RecyclerViewPreloader<>(
-            GlideApp.with(this),
-            modelProvider,
-            sizeProvider,
-            GlideConstants.MAX_PRELOAD_APPSADAPTER);
+            Glide.with(this), modelProvider, sizeProvider, GlideConstants.MAX_PRELOAD_APPSADAPTER);
     linearLayoutManager = new LinearLayoutManager(getContext());
     updateViews(mainActivity, utilsProvider);
 

--- a/app/src/main/java/com/amaze/filemanager/utils/ContextLocaleExt.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/ContextLocaleExt.kt
@@ -21,6 +21,8 @@
 package com.amaze.filemanager.utils
 
 import android.content.Context
+import android.os.Build
+import android.os.Build.VERSION_CODES.N
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import com.amaze.filemanager.R
@@ -48,6 +50,12 @@ fun Context.getLocaleListFromXml(): LocaleListCompat {
         e.printStackTrace()
     } catch (e: IOException) {
         e.printStackTrace()
+    }
+
+    // Remove locale tags that would produce same locale on Android N or above
+    if (Build.VERSION.SDK_INT >= N) {
+        tagsList.remove("id")
+        tagsList.remove("he")
     }
 
     return LocaleListCompat.forLanguageTags(tagsList.joinToString(","))

--- a/app/src/test/java/com/amaze/filemanager/ui/fragments/preferencefragments/UiPrefsFragmentTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/fragments/preferencefragments/UiPrefsFragmentTest.kt
@@ -51,7 +51,12 @@ import kotlin.random.Random
  * Tests for [UiPrefsFragment].
  */
 @Config(
-    sdk = [Build.VERSION_CODES.KITKAT, Build.VERSION_CODES.P, Build.VERSION_CODES.R],
+    sdk = [
+        Build.VERSION_CODES.KITKAT,
+        Build.VERSION_CODES.N,
+        Build.VERSION_CODES.P,
+        Build.VERSION_CODES.R
+    ],
     shadows = [
         ShadowMultiDex::class,
         ShadowStorageManager::class,

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jcifsVersion = '2.1.9'
         fabSpeedDialVersion = '3.1.1'
         roomVersion = '2.5.0'
-        bouncyCastleVersion = '1.70'
+        bouncyCastleVersion = '1.75'
         awaitilityVersion = "3.1.6"
         androidXCoreVersion = "1.7.0"
         androidMaterialVersion = "1.5.0" // Upgrade to 1.5 requires targetSdkVersion 31

--- a/build.gradle
+++ b/build.gradle
@@ -2,48 +2,7 @@
 
 buildscript {
     ext {
-        kotlin_version = "1.8.0"
-        robolectricVersion = '4.9'
-        glideVersion = '4.11.0'
-        sshjVersion = '0.35.0'
-        jcifsVersion = '2.1.10'
-        fabSpeedDialVersion = '3.1.1'
-        roomVersion = '2.5.0'
-        bouncyCastleVersion = '1.76'
-        awaitilityVersion = "3.1.6"
-        androidXCoreVersion = "1.7.0"
-        androidMaterialVersion = "1.5.0" // Upgrade to 1.5 requires targetSdkVersion 31
-        androidXFragmentVersion = "1.5.6"
-        androidXAppCompatVersion = "1.6.1"
-        androidXAnnotationVersion = "1.5.0"
-        androidXPrefVersion = "1.2.1"
-        androidXTestVersion = "1.5.0"
-        androidXTestRunnerVersion = "1.5.2"
-        androidXTestExtVersion = "1.1.5"
-        androidXArchCoreTestVersion = "2.2.0"
-        kotlinxCoroutineTestVersion = "1.7.3"
-        uiAutomatorVersion = "2.2.0"
-        junitVersion = "4.13.2"
-        slf4jVersion = "1.7.25"
-        mockitoVersion = "4.11.0"
-        mockitoInlineVersion = "4.11.0"
-        mockitoKotlinVersion = "4.1.0"
-        androidBillingVersion = "5.0.0"
-        junrarVersion = "7.4.0"
-        zip4jVersion = "2.6.4"
-        espressoVersion = "3.5.1"
-        materialDialogsVersion = "0.9.6.0"
-        jacocoVersion = "0.8.7"
-        commonsCompressVersion = "1.22"
-        libsuVersion = "3.2.1"
-        mockkVersion = "1.12.2"
-        logbackAndroidVersion = "3.0.0"
-        commonsNetVersion = "3.8.0"
-        ftpserverVersion = "1.1.1"
-        jsoupVersion = "1.13.1"
-        rxAndroidVersion = "2.1.1"
-        rxJavaVersion = "2.2.9"
-        okHttpVersion = "4.9.0"
+        kotlin_version = "1.9.10"
     }
     repositories {
         google()
@@ -63,6 +22,7 @@ buildscript {
 
 plugins {
     id "com.diffplug.spotless" version "6.5.0"
+    id "com.google.devtools.ksp" version "1.9.10-1.0.13" apply false
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,10 @@ buildscript {
         robolectricVersion = '4.9'
         glideVersion = '4.11.0'
         sshjVersion = '0.35.0'
-        jcifsVersion = '2.1.9'
+        jcifsVersion = '2.1.10'
         fabSpeedDialVersion = '3.1.1'
         roomVersion = '2.5.0'
-        bouncyCastleVersion = '1.75'
+        bouncyCastleVersion = '1.76'
         awaitilityVersion = "3.1.6"
         androidXCoreVersion = "1.7.0"
         androidMaterialVersion = "1.5.0" // Upgrade to 1.5 requires targetSdkVersion 31

--- a/commons_compress_7z/build.gradle
+++ b/commons_compress_7z/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdkVersion 19
-
+        minSdkVersion libs.versions.minSdk.get().toInteger()
+        targetSdkVersion libs.versions.targetSdk.get().toInteger()
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }
@@ -17,11 +17,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard.cfg'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
 
 }
 
 dependencies {
-    implementation "org.apache.commons:commons-compress:$commonsCompressVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'org.tukaani:xz:1.9'
+    implementation libs.commons.compress
+    implementation libs.kotlin.stdlib.jdk8
+    implementation libs.xz
 }

--- a/file_operations/build.gradle
+++ b/file_operations/build.gradle
@@ -61,11 +61,17 @@ kotlin {
 
 dependencies {
     modules {
+        module("org.bouncycastle:bcprov-jdk15on") {
+            replacedBy("org.bouncycastle:bcprov-jdk18on")
+        }
+        module("org.bouncycastle:bcpkix-jdk15on") {
+            replacedBy("org.bouncycastle:bcpkix-jdk18on")
+        }
         module("org.bouncycastle:bcprov-jdk15to18") {
-            replacedBy("org.bouncycastle:bcprov-jdk15on")
+            replacedBy("org.bouncycastle:bcprov-jdk18on")
         }
         module("org.bouncycastle:bcpkix-jdk15to18") {
-            replacedBy("org.bouncycastle:bcpkix-jdk15on")
+            replacedBy("org.bouncycastle:bcpkix-jdk18on")
         }
     }
 

--- a/file_operations/build.gradle
+++ b/file_operations/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'com.google.devtools.ksp'
 
 android {
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -75,51 +76,47 @@ dependencies {
         }
     }
 
-    implementation "org.apache.commons:commons-compress:$commonsCompressVersion"
+    implementation libs.commons.compress
 
     //zip4j: support password-protected zips
-    implementation "net.lingala.zip4j:zip4j:$zip4jVersion"
+    implementation libs.zip4j
 
     implementation project(':commons_compress_7z')
 
     //SFTP
-    implementation "com.hierynomus:sshj:$sshjVersion"
+    implementation libs.sshj
 
     //smb
-    implementation "eu.agno3.jcifs:jcifs-ng:$jcifsVersion"
+    implementation libs.jcifs.ng
 
-    implementation 'androidx.multidex:multidex:2.0.1'//Multiple dex files
+    implementation libs.androidx.multidex //Multiple dex files
 
     //TODO some libs are not needed
 
     //For tests
-    testImplementation "junit:junit:$junitVersion"//tests the app logic
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"//tests android interaction
-    testImplementation "org.robolectric:shadows-httpclient:$robolectricVersion"//tests android interaction
-    testImplementation "androidx.test:core:$androidXTestVersion"
-    testImplementation "androidx.test:runner:$androidXTestVersion"
-    testImplementation "androidx.test:rules:$androidXTestVersion"
-    testImplementation "androidx.test.ext:junit:$androidXTestExtVersion"
+    testImplementation libs.junit //tests the app logic
+    testImplementation libs.robolectric //tests android interaction
+    testImplementation libs.robolectric.shadows.httpclient //tests android interaction
+    testImplementation libs.androidX.test.core
+    testImplementation libs.androidX.test.runner
+    testImplementation libs.androidX.test.rules
+    testImplementation libs.androidX.test.ext.junit
     //testImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation "org.apache.sshd:sshd-core:1.7.0"
-    testImplementation "org.awaitility:awaitility:$awaitilityVersion"
-    testImplementation 'org.jsoup:jsoup:1.11.2'
-    testAnnotationProcessor "com.google.auto.service:auto-service:1.0-rc4"
+    testImplementation libs.mockito.core
+    testImplementation libs.apache.sshd
+    testImplementation libs.awaitility
+    testImplementation libs.jsoup
+    kspTest libs.auto.service
 
-    androidTestImplementation "junit:junit:$junitVersion"//tests the app logic
-    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
-    androidTestImplementation "androidx.test:core:$androidXTestVersion"
-    androidTestImplementation "androidx.test:runner:$androidXTestVersion"
-    androidTestImplementation "androidx.test:rules:$androidXTestVersion"
-    androidTestImplementation "androidx.test.ext:junit:$androidXTestExtVersion"
-    androidTestImplementation "commons-net:commons-net:$commonsNetVersion"
-    androidTestImplementation "org.awaitility:awaitility:$awaitilityVersion"
+    androidTestImplementation libs.junit //tests the app logic
+    androidTestImplementation libs.androidX.test.expresso
+    androidTestImplementation libs.androidX.test.core
+    androidTestImplementation libs.androidX.test.runner
+    androidTestImplementation libs.androidX.test.rules
+    androidTestImplementation libs.androidX.test.ext.junit
+    androidTestImplementation libs.commons.net
+    androidTestImplementation libs.awaitility
 
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    testImplementation "junit:junit:$junitVersion"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
-
+    implementation libs.androidX.appcompat
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,167 @@
+[versions]
+compileSdk = "33"
+minSdk = "19"
+targetSdk = "33"
+
+kotlin = "1.9.10"
+
+legacySupportV13 = "1.0.0"
+systembartint = "1.0.3"
+robolectric = "4.9"
+glide = "4.14.2"
+sshj = "0.35.0"
+jcifs = "2.1.9"
+eventbus = "3.3.1"
+fabSpeedDial = "3.1.1"
+room = "2.5.2"
+bouncyCastle = "1.76"
+awaitility = "3.1.6"
+androidXCore = "1.7.0"
+androidMaterial = "1.5.0" # Upgrade to 1.5 requires targetSdk 31
+androidXFragment = "1.5.6"
+androidXAppCompat = "1.6.1"
+androidXAnnotation = "1.7.1"
+androidXPref = "1.2.1"
+androidXPalette = "1.0.0"
+androidXCardView = "1.0.0"
+androidXConstraintLayout = "1.1.3"
+androidXTest = "1.5.0"
+androidXTestRunner = "1.5.2"
+androidXTestExt = "1.1.5"
+androidXArchCoreTest = "2.2.0"
+androidXMultidex = "2.0.1"
+autoService = "1.0-rc4"
+kotlinxCoroutineTest = "1.7.3"
+kotlinStdlibJdk8 = "1.9.20"
+uiAutomator = "2.2.0"
+junit = "4.13.2"
+slf4j = "2.0.7"
+apacheSshd = "1.7.0"
+apacheMina = "2.0.16"
+mockito = "4.11.0"
+mockitoInline = "4.11.0"
+mockitoKotlin = "4.1.0"
+androidBilling = "5.0.0"
+cloudrailSiAndroid = "2.22.4"
+junrar = "7.4.0"
+vectordrawableAnimated = "1.1.0"
+xz = "1.9"
+zip4j = "2.6.4"
+espresso = "3.5.1"
+materialDialogs = "0.9.6.0"
+jacoco = "0.8.11"
+commonsCompress = "1.22"
+libsu = "3.2.1"
+mockk = "1.12.2"
+logbackAndroid = "3.0.0"
+logbackClassic = "1.2.11"
+commonsNet = "3.8.0"
+ftpserver = "1.1.1"
+jsoup = "1.13.1"
+gson = "2.9.1"
+rxAndroid = "2.1.1"
+rxJava = "2.2.9"
+okHttp = "4.9.0"
+acraCore = "5.7.0"
+leakcanaryAndroid = "2.7"
+mpAndroidChart = "v3.0.2"
+concurrentTrees = "2.6.1"
+aboutLibraries = "6.1.1"
+amazeTrashBin = "1.0.10"
+
+[libraries]
+androidX-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidXAppCompat" }
+androidX-constraintLayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidXConstraintLayout" }
+androidX-core = { module = "androidx.core:core-ktx", version.ref = "androidXCore" }
+androidX-cardview = { module = "androidx.cardview:cardview", version.ref = "androidXCardView" }
+androidX-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidXArchCoreTest" }
+androidX-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidXFragment"}
+androidX-fragment-testing = { module = "androidx.fragment:fragment-testing", version.ref = "androidXFragment"}
+androidX-material = { module = "com.google.android.material:material", version.ref = "androidMaterial" }
+androidX-legacySupportV13 = { module = "androidx.legacy:legacy-support-v13", version.ref = "legacySupportV13" }
+androidX-annotation = { module = "androidx.annotation:annotation", version.ref = "androidXAnnotation" }
+androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidXMultidex" }
+androidX-palette = { module = "androidx.palette:palette-ktx", version.ref = "androidXPalette" }
+androidX-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidXPref" }
+androidX-vectordrawable-animated = { module = "androidx.vectordrawable:vectordrawable-animated", version.ref = "vectordrawableAnimated" }
+
+androidX-test-core = { module = "androidx.test:core", version.ref = "androidXTest" }
+androidX-test-runner = { module = "androidx.test:runner", version.ref = "androidXTestRunner" }
+androidX-test-rules = { module = "androidx.test:rules", version.ref = "androidXTest" }
+androidX-test-expresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+androidX-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidXTestExt" }
+androidX-test-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiAutomator" }
+
+auto-service = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
+
+bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncyCastle" }
+bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle" }
+
+apache-mina-core = { module = "org.apache.mina:mina-core", version.ref = "apacheMina" }
+apache-sshd = { module = "org.apache.sshd:sshd-core", version.ref = "apacheSshd" }
+apache-ftpserver-ftplet-api = { module = "org.apache.ftpserver:ftplet-api", version.ref = "ftpserver" }
+apache-ftpserver-core = { module = "org.apache.ftpserver:ftpserver-core", version.ref = "ftpserver" }
+
+google-play-billing = { module = "com.android.billingclient:billing", version.ref = "androidBilling" }
+
+cloudrail-si-android = { module = "com.cloudrail:cloudrail-si-android", version.ref = "cloudrailSiAndroid" }
+
+eventbus = { module = "org.greenrobot:eventbus", version.ref = "eventbus" }
+concurrent-trees = { module = "com.github.npgall:concurrent-trees", version.ref = "concurrentTrees" }
+
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
+
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlinStdlibJdk8" }
+kotlin-coroutine-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutineTest" }
+
+libsu-core = { module = "com.github.topjohnwu.libsu:core", version.ref = "libsu" }
+libsu-io = { module = "com.github.topjohnwu.libsu:io", version.ref = "libsu" }
+
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+logback-android = { module = "com.github.tony19:logback-android", version.ref = "logbackAndroid" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logbackClassic" }
+
+room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+room-rxjava2 = { module = "androidx.room:room-rxjava2", version.ref = "room" }
+room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+room-migration = { module = "androidx.room:room-migration", version.ref = "room" }
+
+commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commonsCompress" }
+commons-net = { module = "commons-net:commons-net", version.ref = "commonsNet" }
+
+materialdialogs-core = { module = "com.afollestad.material-dialogs:core", version.ref = "materialDialogs" }
+materialdialogs-commons = { module = "com.afollestad.material-dialogs:commons", version.ref = "materialDialogs" }
+mpAndroidChart = { module = "com.github.PhilJay:MPAndroidChart", version.ref = "mpAndroidChart" }
+aboutLibraries = { module = "com.mikepenz:aboutlibraries", version.ref = "aboutLibraries" }
+
+jcifs-ng = { module = "eu.agno3.jcifs:jcifs-ng", version.ref = "jcifs" }
+speedDial = { module = "com.leinardi.android:speed-dial", version.ref = "fabSpeedDial" }
+sshj = { module = "com.hierynomus:sshj", version.ref = "sshj" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okHttp" }
+
+junit = { module = "junit:junit", version.ref = "junit" }
+awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
+mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+robolectric-shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }
+
+glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
+glide-recyclerView = { module = "com.github.bumptech.glide:recyclerview-integration", version.ref = "glide" }
+glide-ksp = { module = "com.github.bumptech.glide:ksp", version.ref = "glide" }
+systembarTint = { module = "com.readystatesoftware.systembartint:systembartint", version.ref = "systembartint" }
+
+rxandroid = { module = "io.reactivex.rxjava2:rxandroid", version.ref = "rxAndroid" }
+rxjava = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rxJava" }
+
+xz = { module = "org.tukaani:xz", version.ref = "xz" }
+zip4j = { module = "net.lingala.zip4j:zip4j", version.ref = "zip4j" }
+junrar = { module = "com.github.junrar:junrar", version.ref = "junrar" }
+
+acra-core = { module = "ch.acra:acra-core", version.ref = "acraCore" }
+leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanaryAndroid" }
+
+amaze-trashBin = { module = "com.github.TeamAmaze:AmazeTrashBin", version.ref = "amazeTrashBin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat May 22 22:20:14 ART 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/portscanner/build.gradle
+++ b/portscanner/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'kotlin-parcelize'
 
 android {
     namespace 'com.stealthcopter.networktools'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 14
-        targetSdk 33
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdk libs.versions.targetSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -32,10 +32,10 @@ kotlin {
 }
 
 dependencies {
-    implementation "io.reactivex.rxjava2:rxandroid:$rxAndroidVersion"
+    implementation libs.rxandroid
     // Because RxAndroid releases are few and far between, it is recommended you also
     // explicitly depend on RxJava's latest version for bug fixes and new features.
     // (see https://github.com/ReactiveX/RxJava/releases for latest 3.x.x version)
-    implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
-    testImplementation "junit:junit:$junitVersion"
+    implementation libs.rxjava
+    testImplementation libs.junit
 }


### PR DESCRIPTION
## Description
Bump sshj, jcifs-ng and Bouncy Castle dependencies, in response to #4091

Additionally,

- [Use `ksp` for faster processing of source code](https://developer.android.com/build/migrate-to-ksp)
- Migrate code from using generated Glide classes to [recommended ones by Glide itself](https://bumptech.github.io/glide/doc/generatedapi.html)
- Bump AndroidX annotation, Room and Glide versions
- Bump Kotlin to 1.9.10
- Migrate version and lib names to [version catalogs](https://developer.android.com/build/migrate-to-catalogs) or in other words, `libs.versions.toml` 

#### Issue tracker   
Fixes #4091
Fixes #4088

#### Automatic tests
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 6 emulator
- OS: Android 13
SMB and SSH connections should continue to work

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #4085, the same [e7eb3d8](https://github.com/TeamAmaze/AmazeFileManager/pull/4085/commits/e7eb3d87cb04624a6799f048d4e5b410c4177d27) was cherry-picked into this PR to keep the test pass