### PR TITLE
Keep connection alive at HybridFile.forEachChildrenFile()

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/HybridFile.java
@@ -960,7 +960,7 @@ public class HybridFile {
     switch (mode) {
       case SFTP:
         SshClientUtils.execute(
-            new SFtpClientTemplate<Boolean>(getPath(), true) {
+            new SFtpClientTemplate<Boolean>(getPath(), false) {
               @Override
               public Boolean execute(@NonNull SFTPClient client) {
                 try {


### PR DESCRIPTION
## Description
Keep the connection alive on HybridFile.forEachChildrenFile() to fix the problem with SSH connections having specified path to open on connect

#### Issue tracker   
Address #4081
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 6 emulator
- OS: Android 13

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [ ] `./gradlew assembledebug`
- [ ] `./gradlew spotlessCheck`