### PR TITLE
Add guard for empty string at port textfield in SftpConnectionDialog

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.kt
@@ -32,7 +32,6 @@ import android.text.Editable
 import android.text.InputFilter
 import android.text.TextUtils
 import android.text.TextWatcher
-import android.view.LayoutInflater
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
@@ -55,6 +54,7 @@ import com.amaze.filemanager.fileoperations.filesystem.OpenMode
 import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool
 import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.FTPS_URI_PREFIX
 import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.FTP_URI_PREFIX
+import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.SSH_DEFAULT_PORT
 import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.SSH_URI_PREFIX
 import com.amaze.filemanager.filesystem.ftp.NetCopyClientUtils
 import com.amaze.filemanager.filesystem.ftp.NetCopyConnectionInfo.Companion.COLON
@@ -82,7 +82,6 @@ import java.io.BufferedReader
 import java.lang.ref.WeakReference
 import java.security.KeyPair
 import java.security.PublicKey
-import java.util.*
 import java.util.concurrent.Callable
 
 /** SSH/SFTP connection setup dialog.  */
@@ -132,7 +131,7 @@ class SftpConnectDialog : DialogFragment() {
     @Suppress("ComplexMethod")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         ctx = WeakReference(activity)
-        binding = SftpDialogBinding.inflate(LayoutInflater.from(context))
+        binding = SftpDialogBinding.inflate(layoutInflater)
         val utilsProvider: UtilitiesProvider = AppConfig.getInstance().utilsProvider
         val edit = requireArguments().getBoolean(ARG_EDIT, false)
 
@@ -790,7 +789,13 @@ class SftpConnectDialog : DialogFragment() {
             prefix = getProtocolPrefixFromDropdownSelection(),
             connectionName = binding.connectionET.text.toString(),
             hostname = binding.ipET.text.toString(),
-            port = binding.portET.text.toString().toInt(),
+            port = binding.portET.text.toString().let {
+                if (it.isEmpty() || it.isBlank()) {
+                    SSH_DEFAULT_PORT
+                } else {
+                    it.toInt()
+                }
+            },
             defaultPath = binding.defaultPathET.text.toString(),
             username = binding.usernameET.text.toString().urlEncoded(),
             password = if (true == binding.passwordET.text?.isEmpty()) {

--- a/app/src/main/java/com/amaze/filemanager/utils/ContextLocaleExt.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/ContextLocaleExt.kt
@@ -21,6 +21,8 @@
 package com.amaze.filemanager.utils
 
 import android.content.Context
+import android.os.Build
+import android.os.Build.VERSION_CODES.N
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import com.amaze.filemanager.R
@@ -48,6 +50,12 @@ fun Context.getLocaleListFromXml(): LocaleListCompat {
         e.printStackTrace()
     } catch (e: IOException) {
         e.printStackTrace()
+    }
+
+    // Remove locale tags that would produce same locale on Android N or above
+    if (Build.VERSION.SDK_INT >= N) {
+        tagsList.remove("id")
+        tagsList.remove("he")
     }
 
     return LocaleListCompat.forLanguageTags(tagsList.joinToString(","))

--- a/app/src/test/java/com/amaze/filemanager/ui/fragments/preferencefragments/UiPrefsFragmentTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/fragments/preferencefragments/UiPrefsFragmentTest.kt
@@ -51,7 +51,12 @@ import kotlin.random.Random
  * Tests for [UiPrefsFragment].
  */
 @Config(
-    sdk = [Build.VERSION_CODES.KITKAT, Build.VERSION_CODES.P, Build.VERSION_CODES.R],
+    sdk = [
+        Build.VERSION_CODES.KITKAT,
+        Build.VERSION_CODES.N,
+        Build.VERSION_CODES.P,
+        Build.VERSION_CODES.R
+    ],
     shadows = [
         ShadowMultiDex::class,
         ShadowStorageManager::class,


### PR DESCRIPTION
## Description

#### Issue tracker   
Fixes #4122

#### Manual tests
- [x] Done  
  
- Device: Pixel 4a emulator
- OS: Android 12
When connection is set up with server port at 22, editing connection should not crash the app

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #4092 - cherry picked 88ac4ed to make tests pass