### PR TITLE
Upgrade to Node 20 in GitHub Action

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   check_spotless:
     name: Check spotless
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 11
@@ -28,7 +28,7 @@ jobs:
 
   build:
     name: Build debug
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 11

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -15,14 +15,14 @@ jobs:
     name: Check spotless
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 11
       - name: Check formatting using spotless
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: spotlessCheck --stacktrace
 
@@ -30,13 +30,13 @@ jobs:
     name: Build debug
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 11
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assembledebug --stacktrace

--- a/.github/workflows/android-debug-artifact-ondemand.yml
+++ b/.github/workflows/android-debug-artifact-ondemand.yml
@@ -30,27 +30,27 @@ jobs:
           echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
           echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
       - name: Checkout PR Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
           ref: ${{fromJson(steps.request.outputs.data).head.ref}}
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 11
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assembleDebug --stacktrace
       - name: Upload fdroid artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Amaze-Fdroid-debug
           path: app/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk
       - name: Upload play artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Amaze-Play-debug
           path: app/build/outputs/apk/play/debug/app-play-debug.apk

--- a/.github/workflows/android-debug-artifact-ondemand.yml
+++ b/.github/workflows/android-debug-artifact-ondemand.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   apk:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event.comment.body == 'Build test apk' && (github.actor == 'VishalNehra' || github.actor == 'TranceLove' || github.actor == 'EmmanuelMess' || github.actor == 'VishnuSanal')
     steps:
       - name: Acknowledge the request with thumbs up reaction

--- a/.github/workflows/android-debug-artifact-release.yml
+++ b/.github/workflows/android-debug-artifact-release.yml
@@ -8,23 +8,23 @@ jobs:
   apk:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 11
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assembleDebug
       - name: Upload fdroid artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Amaze-Fdroid-debug
           path: app/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk
       - name: Upload play artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Amaze-Play-debug
           path: app/build/outputs/apk/play/debug/app-play-debug.apk

--- a/.github/workflows/android-debug-artifact-release.yml
+++ b/.github/workflows/android-debug-artifact-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   apk:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 11

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -16,14 +16,14 @@ jobs:
     name: Check spotless
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 11
       - name: Check formatting using spotless
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: spotlessCheck --stacktrace
 
@@ -31,17 +31,17 @@ jobs:
     name: Build debug and run Jacoco tests
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 11
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assembledebug --stacktrace
       - name: Run test cases
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: jacocoTestPlayDebugUnitTestReport --stacktrace --info

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   check_spotless:
     name: Check spotless
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 11
@@ -29,7 +29,7 @@ jobs:
 
   build:
     name: Build debug and run Jacoco tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 11

--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   check_spotless:
     name: Check spotless
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 11
@@ -29,7 +29,7 @@ jobs:
 
   build:
     name: Build debug, Jacoco test and publish to codacy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -16,14 +16,14 @@ jobs:
     name: Check spotless
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 11
       - name: Check formatting using spotless
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: spotlessCheck
 
@@ -31,20 +31,20 @@ jobs:
     name: Build debug, Jacoco test and publish to codacy
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 11
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assembledebug
       - name: Run test cases
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: jacocoTestPlayDebugUnitTestReport
       - name: Publish test cases
@@ -70,15 +70,15 @@ jobs:
         api-level: [ 16, 19, 28 ]
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Java 15
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 15
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/actions/setup-gradle@v3
       - name: AVD cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: avd-cache
         with:
           path: |


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-java@v3, gradle/gradle-build-action@v2.4.2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

- **ci: upgrade github action version**
- **ci: upgrade runner image to ubuntu-latest(ubuntu-22.04)**

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
<!-- Fixes # -->
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->
