### PR TITLE
FAB Visibility Glitch Fixed

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/adapters/HiddenAdapter.kt
+++ b/app/src/main/java/com/amaze/filemanager/adapters/HiddenAdapter.kt
@@ -39,7 +39,6 @@ import com.amaze.filemanager.ui.activities.MainActivity
 import com.amaze.filemanager.ui.fragments.MainFragment
 import com.amaze.filemanager.utils.DataUtils
 import java.io.File
-import java.util.ArrayList
 import kotlin.concurrent.thread
 
 /**
@@ -107,6 +106,8 @@ class HiddenAdapter(
                 val fragmentActivity = mainFragment.requireActivity()
                 if (file.isDirectory(context)) {
                     fragmentActivity.runOnUiThread {
+                        mainFragment.hideFab = false
+                        mainFragment.requireMainActivity().showFab()
                         mainFragment.loadlist(
                             file.path,
                             false,


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description

FAB visibility issue fixed, updating hideFab from HiddenAdapter if hybridFile is directory.

fixes #4130

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
<!-- Fixes # -->
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->