### PR TITLE
Fix wired build error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,7 +144,7 @@ dependencies {
     implementation libs.androidX.palette
     implementation libs.androidX.cardview
     implementation libs.androidX.constraintLayout
-    implementation libs.androidx.multidex //Multiple dex files
+    implementation libs.androidX.multidex //Multiple dex files
     implementation libs.room.runtime
     implementation libs.room.rxjava2
 

--- a/file_operations/build.gradle
+++ b/file_operations/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     //smb
     implementation libs.jcifs.ng
 
-    implementation libs.androidx.multidex //Multiple dex files
+    implementation libs.androidX.multidex //Multiple dex files
 
     //TODO some libs are not needed
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,7 +80,7 @@ androidX-fragment-testing = { module = "androidx.fragment:fragment-testing", ver
 androidX-material = { module = "com.google.android.material:material", version.ref = "androidMaterial" }
 androidX-legacySupportV13 = { module = "androidx.legacy:legacy-support-v13", version.ref = "legacySupportV13" }
 androidX-annotation = { module = "androidx.annotation:annotation", version.ref = "androidXAnnotation" }
-androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidXMultidex" }
+androidX-multidex = { module = "androidx.multidex:multidex", version.ref = "androidXMultidex" }
 androidX-palette = { module = "androidx.palette:palette-ktx", version.ref = "androidXPalette" }
 androidX-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidXPref" }
 androidX-vectordrawable-animated = { module = "androidx.vectordrawable:vectordrawable-animated", version.ref = "vectordrawableAnimated" }


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
Error:
```
$ ./gradlew assembleFdroidRelease

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'amaze'.
> Could not create an instance of type org.gradle.accessors.dm.LibrariesForLibs.
   > Could not generate a decorated class for type LibrariesForLibs.
      > org/gradle/accessors/dm/LibrariesForLibs$AndroidxLibraryAccessors (wrong name: org/gradle/accessors/dm/LibrariesForLibs$AndroidXLibraryAccessors)
```

Analysis:
Find all string `AndroidxLibraryAccessors`

```
grep -r AndroidXLibraryAccessors .
```

Before:
```
/**
 * A catalog of dependencies accessible via the `libs` extension.
*/
@NonNullApi
public class LibrariesForLibs extends AbstractExternalDependencyFactory {

    private final AbstractExternalDependencyFactory owner = this;
    private final AcraLibraryAccessors laccForAcraLibraryAccessors = new AcraLibraryAccessors(owner);
    private final AmazeLibraryAccessors laccForAmazeLibraryAccessors = new AmazeLibraryAccessors(owner);

    private final AndroidXLibraryAccessors laccForAndroidXLibraryAccessors = new AndroidXLibraryAccessors(owner);
    private final AndroidxLibraryAccessors laccForAndroidxLibraryAccessors = new AndroidxLibraryAccessors(owner);
```

After:
```
/**
 * A catalog of dependencies accessible via the `libs` extension.
*/
@NonNullApi
public class LibrariesForLibs extends AbstractExternalDependencyFactory {

    private final AbstractExternalDependencyFactory owner = this;
    private final AcraLibraryAccessors laccForAcraLibraryAccessors = new AcraLibraryAccessors(owner);
    private final AmazeLibraryAccessors laccForAmazeLibraryAccessors = new AmazeLibraryAccessors(owner);
    private final AndroidXLibraryAccessors laccForAndroidXLibraryAccessors = new AndroidXLibraryAccessors(owner);
    private final ApacheLibraryAccessors laccForApacheLibraryAccessors = new ApacheLibraryAccessors(owner);
```

No class conflict(AndroidXLibraryAccessors vs AndroidxLibraryAccessors) anymore.

Root cause:
Seems this bug only show up on gradle 7.x(7.5 and 7.6.4) not gradle 8.7.

macOS is not a case sensitive file system by default, so the CI passed in Linux and failed in macOS.


#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
Fixes #4157
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [x] Added test cases
  
#### Manual tests
- [x] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->

