### PR TITLE
Add explicit TLS option for FTPSClient

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -161,6 +161,7 @@ public class LoadFilesListTask
       case SMB:
         list = listSmb(hFile, mainActivityViewModel, mainFragment);
         break;
+      case FTP:
       case SFTP:
         list = listSftp(mainActivityViewModel);
         break;

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ftp/auth/FtpAuthenticationTask.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ftp/auth/FtpAuthenticationTask.kt
@@ -38,6 +38,7 @@ class FtpAuthenticationTask(
     private val certInfo: JSONObject?,
     private val username: String,
     private val password: String?,
+    private val explicitTls: Boolean = false,
 ) : Task<FTPClient, FtpAuthenticationTaskCallable> {
     override fun getTask(): FtpAuthenticationTaskCallable {
         return if (protocol == FTP_URI_PREFIX) {
@@ -54,6 +55,7 @@ class FtpAuthenticationTask(
                 certInfo!!,
                 username,
                 password ?: "",
+                explicitTls,
             )
         }
     }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ftp/auth/FtpsAuthenticationTaskCallable.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ftp/auth/FtpsAuthenticationTaskCallable.kt
@@ -22,6 +22,8 @@ package com.amaze.filemanager.asynchronous.asynctasks.ftp.auth
 
 import com.amaze.filemanager.application.AppConfig
 import com.amaze.filemanager.filesystem.ftp.FTPClientImpl
+import com.amaze.filemanager.filesystem.ftp.FTPClientImpl.Companion.ARG_TLS
+import com.amaze.filemanager.filesystem.ftp.FTPClientImpl.Companion.TLS_EXPLICIT
 import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool
 import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.FTPS_URI_PREFIX
 import com.amaze.filemanager.utils.PasswordUtil
@@ -39,6 +41,7 @@ class FtpsAuthenticationTaskCallable(
     private val certInfo: JSONObject,
     username: String,
     password: String,
+    private val explicitTls: Boolean,
 ) : FtpAuthenticationTaskCallable(hostname, port, username, password) {
     override fun call(): FTPClient {
         val ftpClient = createFTPClient() as FTPSClient
@@ -71,8 +74,15 @@ class FtpsAuthenticationTaskCallable(
 
     @Suppress("LabeledExpression")
     override fun createFTPClient(): FTPClient {
+        val uri =
+            buildString {
+                append(FTPS_URI_PREFIX)
+                if (explicitTls) {
+                    append("?$ARG_TLS=$TLS_EXPLICIT")
+                }
+            }
         return (
-            NetCopyClientConnectionPool.ftpClientFactory.create(FTPS_URI_PREFIX)
+            NetCopyClientConnectionPool.ftpClientFactory.create(uri.toString())
                 as FTPSClient
         ).apply {
             this.hostnameVerifier =

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ftp/hostcert/FtpsGetHostCertificateTask.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ftp/hostcert/FtpsGetHostCertificateTask.kt
@@ -28,10 +28,11 @@ import java.lang.ref.WeakReference
 class FtpsGetHostCertificateTask(
     private val host: String,
     private val port: Int,
+    private val explicitTls: Boolean = false,
     context: Context,
     callback: (JSONObject) -> Unit,
 ) : AbstractGetHostInfoTask<JSONObject, FtpsGetHostCertificateTaskCallable>(host, port, callback) {
     val ctx: WeakReference<Context> = WeakReference(context)
 
-    override fun getTask(): FtpsGetHostCertificateTaskCallable = FtpsGetHostCertificateTaskCallable(host, port)
+    override fun getTask(): FtpsGetHostCertificateTaskCallable = FtpsGetHostCertificateTaskCallable(host, port, explicitTls)
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ftp/hostcert/FtpsGetHostCertificateTaskCallable.kt
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ftp/hostcert/FtpsGetHostCertificateTaskCallable.kt
@@ -21,6 +21,8 @@
 package com.amaze.filemanager.asynchronous.asynctasks.ftp.hostcert
 
 import androidx.annotation.WorkerThread
+import com.amaze.filemanager.filesystem.ftp.FTPClientImpl.Companion.ARG_TLS
+import com.amaze.filemanager.filesystem.ftp.FTPClientImpl.Companion.TLS_EXPLICIT
 import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool
 import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.CONNECT_TIMEOUT
 import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.FTPS_URI_PREFIX
@@ -34,6 +36,7 @@ import javax.net.ssl.HostnameVerifier
 open class FtpsGetHostCertificateTaskCallable(
     private val hostname: String,
     private val port: Int,
+    private val explicitTls: Boolean = false,
 ) : Callable<JSONObject> {
     @WorkerThread
     override fun call(): JSONObject? {
@@ -57,5 +60,12 @@ open class FtpsGetHostCertificateTaskCallable(
         return result
     }
 
-    protected open fun createFTPClient(): FTPSClient = NetCopyClientConnectionPool.ftpClientFactory.create(FTPS_URI_PREFIX) as FTPSClient
+    protected open fun createFTPClient(): FTPSClient =
+        NetCopyClientConnectionPool.ftpClientFactory.create(
+            if (explicitTls) {
+                "$FTPS_URI_PREFIX?$ARG_TLS=$TLS_EXPLICIT"
+            } else {
+                FTPS_URI_PREFIX
+            },
+        ) as FTPSClient
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ftp/FTPClientImpl.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ftp/FTPClientImpl.kt
@@ -34,8 +34,11 @@ class FTPClientImpl(private val ftpClient: FTPClient) : NetCopyClient<FTPClient>
         @JvmStatic
         private val logger: Logger = LoggerFactory.getLogger(FTPClientImpl::class.java)
 
-        @JvmStatic
-        val ANONYMOUS = "anonymous"
+        const val ANONYMOUS = "anonymous"
+
+        const val ARG_TLS = "tls"
+
+        const val TLS_EXPLICIT = "explicit"
 
         private const val ALPHABET = "abcdefghijklmnopqrstuvwxyz1234567890"
 

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ftp/NetCopyConnectionInfo.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ftp/NetCopyConnectionInfo.kt
@@ -70,6 +70,7 @@ class NetCopyConnectionInfo(url: String) {
         const val AT = '@'
         const val SLASH = '/'
         const val COLON = ':'
+        const val QUESTION_MARK = '?'
     }
 
     init {
@@ -157,7 +158,7 @@ class NetCopyConnectionInfo(url: String) {
     }
 
     override fun toString(): String {
-        return if (username.isNotEmpty()) {
+        return if (username.isNotBlank() && username.isNotEmpty()) {
             "$prefix$username@$host${if (port == 0) "" else ":$port"}${defaultPath ?: ""}"
         } else {
             "$prefix$host${if (port == 0) "" else ":$port"}${defaultPath ?: ""}"

--- a/app/src/main/java/com/amaze/filemanager/utils/smb/SmbUtil.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/smb/SmbUtil.kt
@@ -29,6 +29,7 @@ import com.amaze.filemanager.fileoperations.filesystem.WRITABLE_ON_REMOTE
 import com.amaze.filemanager.filesystem.ftp.NetCopyConnectionInfo
 import com.amaze.filemanager.filesystem.ftp.NetCopyConnectionInfo.Companion.AT
 import com.amaze.filemanager.filesystem.ftp.NetCopyConnectionInfo.Companion.COLON
+import com.amaze.filemanager.filesystem.ftp.NetCopyConnectionInfo.Companion.QUESTION_MARK
 import com.amaze.filemanager.filesystem.smb.CifsContexts.createWithDisableIpcSigningCheck
 import com.amaze.filemanager.utils.PasswordUtil
 import com.amaze.filemanager.utils.urlDecoded
@@ -99,6 +100,9 @@ object SmbUtil {
             }
             connectionInfo.defaultPath?.apply {
                 buffer.append(this)
+            }
+            if (path.contains(QUESTION_MARK)) {
+                buffer.append(QUESTION_MARK).append(path.substringAfter(QUESTION_MARK))
             }
         }
         return buffer.toString().replace("\n", "")

--- a/app/src/main/res/layout/sftp_dialog.xml
+++ b/app/src/main/res/layout/sftp_dialog.xml
@@ -134,11 +134,20 @@
         app:layout_constraintTop_toBottomOf="@id/passwordTIL"
         android:layout_gravity="center_horizontal"/>
 
+    <androidx.appcompat.widget.AppCompatCheckBox
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/chkFtpExplicitTls"
+        android:text="@string/ftps_enable_explicit_tls"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/chkFtpAnonymous"
+        android:layout_gravity="center_horizontal"/>
+
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/selectPemTIL"
         app:errorEnabled="true"
         app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/chkFtpAnonymous"
+        app:layout_constraintTop_toBottomOf="@id/chkFtpExplicitTls"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -593,6 +593,7 @@
 	<string name="scp_connection">SCP/SFTP Connection</string>
     <string name="ftp_connection">FTP Connection</string>
     <string name="ftps_connection">FTP over SSL Connection</string>
+    <string name="ftps_enable_explicit_tls">Explicit TLS</string>
     <string name="scp_port">Port</string>
     <string name="ssh_host_key_verification_prompt">The authenticity of host \'%1$s\' can\'t be established.\n\n%2$s key fingerprint is %3$s.\n\nPlease tap \"Yes\" to confirm identity; otherwise, please tap \"No\".</string>
     <string name="ssh_host_key_verification_prompt_title">Verify Host</string>

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ftp/NetCopyClientConnectionPoolTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ftp/NetCopyClientConnectionPoolTest.kt
@@ -1,0 +1,64 @@
+package com.amaze.filemanager.filesystem.ftp
+
+import org.apache.commons.net.ftp.FTPSClient
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [NetCopyClientConnectionPool]
+ */
+@Suppress("StringLiteralDuplication")
+class NetCopyClientConnectionPoolTest {
+    /**
+     * Test DefaultFTPClientFactory default behaviour with FTPClient
+     */
+    @Test
+    fun `DefaultFTPClientFactory default behaviour with FTPClient`() {
+        val factory = NetCopyClientConnectionPool.DefaultFTPClientFactory()
+        val result = factory.create("ftp://127.0.0.1:2121")
+        assertFalse(result is FTPSClient)
+    }
+
+    /**
+     * Test DefaultFTPClientFactory default behaviour with FTPSClient
+     */
+    @Test
+    fun `DefaultFTPClientFactory default behaviour with FTPSClient`() {
+        val factory = NetCopyClientConnectionPool.DefaultFTPClientFactory()
+        val result = factory.create("ftps://127.0.0.1:2121")
+        assertTrue(result is FTPSClient)
+        val isImplicit = FTPSClient::class.java.getDeclaredField("isImplicit")
+        isImplicit.isAccessible = true
+        assertTrue(isImplicit.get(result) as Boolean)
+    }
+
+    /**
+     * Test DefaultFTPClientFactory with URI having tls != explicit
+     */
+    @Test
+    fun `DefaultFTPClientFactory with URI having tls != explicit`() {
+        val factory = NetCopyClientConnectionPool.DefaultFTPClientFactory()
+        var result = factory.create("ftps://127.0.0.1:2121?tls=implicit")
+        assertTrue(result is FTPSClient)
+        val isImplicit = FTPSClient::class.java.getDeclaredField("isImplicit")
+        isImplicit.isAccessible = true
+        assertTrue(isImplicit.get(result) as Boolean)
+        result = factory.create("ftps://127.0.0.1:2121?explicitTls=true")
+        assertTrue(result is FTPSClient)
+        assertTrue(isImplicit.get(result) as Boolean)
+    }
+
+    /**
+     * Test DefaultFTPClientDirectory with URI having tls=explicit
+     */
+    @Test
+    fun `DefaultFTPClientDirectory with URI having tls=explicit`() {
+        val factory = NetCopyClientConnectionPool.DefaultFTPClientFactory()
+        val result = factory.create("ftps://127.0.0.1:2121?tls=explicit")
+        assertTrue(result is FTPSClient)
+        val isImplicit = FTPSClient::class.java.getDeclaredField("isImplicit")
+        isImplicit.isAccessible = true
+        assertFalse(isImplicit.get(result) as Boolean)
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ftp/NetCopyClientUtilTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ftp/NetCopyClientUtilTest.kt
@@ -140,5 +140,25 @@ class NetCopyClientUtilTest {
             "ftp://127.0.0.1:2211",
             NetCopyClientUtils.extractBaseUriFrom("ftp://127.0.0.1:2211/pub/notice.txt"),
         )
+        assertEquals(
+            "ftps://127.0.0.1:21221?tls=explicit",
+            NetCopyClientUtils.extractBaseUriFrom("ftps://127.0.0.1:21221?tls=explicit"),
+        )
+        assertEquals(
+            "ftps://127.0.0.1:21221?tls=explicit",
+            NetCopyClientUtils.extractBaseUriFrom("ftps://127.0.0.1:21221/tmp/pub?tls=explicit"),
+        )
+        assertEquals(
+            "ftps://127.0.0.1:21221?tls=explicit",
+            NetCopyClientUtils.extractBaseUriFrom("ftps://127.0.0.1:21221/pub/Incoming/shared/test.txt?tls=explicit"),
+        )
+        assertEquals(
+            "ssh://root@127.0.0.1:22222?foo=bar&timeout=3000&2fa=true",
+            NetCopyClientUtils.extractBaseUriFrom("ssh://root@127.0.0.1:22222?foo=bar&timeout=3000&2fa=true"),
+        )
+        assertEquals(
+            "ssh://root@127.0.0.1:22222?foo=bar&timeout=3000&2fa=true",
+            NetCopyClientUtils.extractBaseUriFrom("ssh://root@127.0.0.1:22222/mnt/data?foo=bar&timeout=3000&2fa=true"),
+        )
     }
 }

--- a/app/src/test/java/com/amaze/filemanager/ui/dialogs/AbstractSftpConnectDialogTests.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/dialogs/AbstractSftpConnectDialogTests.kt
@@ -1,0 +1,54 @@
+package com.amaze.filemanager.ui.dialogs
+
+import com.amaze.filemanager.ui.activities.AbstractMainActivityTestBase
+import org.junit.After
+import org.junit.Before
+import org.mockito.MockedConstruction
+import org.mockito.Mockito.mockConstruction
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doCallRealMethod
+
+abstract class AbstractSftpConnectDialogTests : AbstractMainActivityTestBase() {
+    protected lateinit var mc: MockedConstruction<SftpConnectDialog>
+
+    /**
+     * Setups before test.
+     */
+    @Before
+    override fun setUp() {
+        super.setUp()
+        mc =
+            mockConstruction(
+                SftpConnectDialog::class.java,
+            ) { mock: SftpConnectDialog, _: MockedConstruction.Context? ->
+                doCallRealMethod().`when`(mock).arguments = any()
+                `when`(mock.arguments).thenCallRealMethod()
+            }
+    }
+
+    /**
+     * Post test cleanups.
+     */
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        mc.close()
+    }
+
+    companion object {
+        @JvmStatic
+        protected val BUNDLE_KEYS =
+            arrayOf(
+                "address",
+                "port",
+                "keypairName",
+                "name",
+                "username",
+                "password",
+                "edit",
+                "defaultPath",
+                "tls",
+            )
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/ui/dialogs/AbstractSftpConnectDialogUiTests.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/dialogs/AbstractSftpConnectDialogUiTests.kt
@@ -1,0 +1,42 @@
+package com.amaze.filemanager.ui.dialogs
+
+import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import com.afollestad.materialdialogs.MaterialDialog
+import com.amaze.filemanager.ui.activities.AbstractMainActivityTestBase
+import com.amaze.filemanager.ui.activities.MainActivity
+import org.junit.Assert.assertTrue
+import org.robolectric.shadows.ShadowDialog
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * Base class for [SftpConnectDialog] UI level tests.
+ */
+abstract class AbstractSftpConnectDialogUiTests : AbstractMainActivityTestBase() {
+    /**
+     * Create and display [SftpConnectDialog] with Robolectric and AndroidX test.
+     *
+     * @param arguments [Bundle] of arguments
+     * @param withDialog Lambda performing test
+     */
+    protected fun doTestWithDialog(
+        arguments: Bundle,
+        withDialog: (SftpConnectDialog, MaterialDialog) -> Unit,
+    ) {
+        val scenario = ActivityScenario.launch(MainActivity::class.java)
+        ShadowLooper.idleMainLooper()
+        scenario.moveToState(Lifecycle.State.STARTED)
+        scenario.onActivity { activity ->
+            SftpConnectDialog().run {
+                this.arguments = arguments
+                this.show(activity.supportFragmentManager, SftpConnectDialog.TAG)
+                ShadowLooper.runUiThreadTasks()
+                assertTrue(ShadowDialog.getLatestDialog().isShowing)
+                withDialog.invoke(this, ShadowDialog.getLatestDialog() as MaterialDialog)
+            }
+            scenario.moveToState(Lifecycle.State.DESTROYED)
+            scenario.close()
+        }
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialogArgumentPopulationTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialogArgumentPopulationTest.kt
@@ -1,0 +1,276 @@
+package com.amaze.filemanager.ui.dialogs
+
+import android.os.Bundle
+import com.amaze.filemanager.application.AppConfig
+import com.amaze.filemanager.filesystem.ftp.FTPClientImpl.Companion.ARG_TLS
+import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.FTP_URI_PREFIX
+import com.amaze.filemanager.ui.dialogs.SftpConnectDialog.Companion.ARG_ADDRESS
+import com.amaze.filemanager.ui.dialogs.SftpConnectDialog.Companion.ARG_DEFAULT_PATH
+import com.amaze.filemanager.ui.dialogs.SftpConnectDialog.Companion.ARG_EDIT
+import com.amaze.filemanager.ui.dialogs.SftpConnectDialog.Companion.ARG_HAS_PASSWORD
+import com.amaze.filemanager.ui.dialogs.SftpConnectDialog.Companion.ARG_NAME
+import com.amaze.filemanager.ui.dialogs.SftpConnectDialog.Companion.ARG_PASSWORD
+import com.amaze.filemanager.ui.dialogs.SftpConnectDialog.Companion.ARG_PORT
+import com.amaze.filemanager.ui.dialogs.SftpConnectDialog.Companion.ARG_PROTOCOL
+import com.amaze.filemanager.ui.dialogs.SftpConnectDialog.Companion.ARG_USERNAME
+import com.amaze.filemanager.utils.PasswordUtil
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests [SftpConnectDialog] populating arguments to UI at edit mode.
+ */
+@Suppress("StringLiteralDuplication")
+class SftpConnectDialogArgumentPopulationTest : AbstractSftpConnectDialogUiTests() {
+    /**
+     * Test scenario with FTP, username and password
+     */
+    @Test
+    fun testFtpWithUsernamePassword() {
+        doTestWithDialog(
+            arguments =
+                Bundle().also {
+                    it.putString(ARG_PROTOCOL, FTP_URI_PREFIX)
+                    it.putString(ARG_NAME, "FTP Connection")
+                    it.putString(ARG_ADDRESS, "127.0.0.1")
+                    it.putInt(ARG_PORT, 2121)
+                    it.putString(ARG_USERNAME, "root")
+                    it.putString(
+                        ARG_PASSWORD,
+                        PasswordUtil.encryptPassword(
+                            AppConfig.getInstance(),
+                            "abcdefgh",
+                        ),
+                    )
+                    it.putBoolean(ARG_HAS_PASSWORD, true)
+                    it.putBoolean(ARG_EDIT, true)
+                },
+            withDialog = { sftpConnectDialog, materialDialog ->
+                assertNotNull(sftpConnectDialog.binding)
+                requireNotNull(sftpConnectDialog.binding).let { binding ->
+                    assertFalse(binding.chkFtpExplicitTls.isChecked)
+                    assertFalse(binding.chkFtpAnonymous.isChecked)
+                    assertEquals(2121, binding.portET.text.toString().toInt())
+                    assertEquals("root", binding.usernameET.text.toString())
+                    assertEquals("FTP Connection", binding.connectionET.text.toString())
+                    assertEquals(1, binding.protocolDropDown.selectedItemPosition)
+                    assertEquals("", binding.passwordET.text.toString())
+                }
+            },
+        )
+    }
+
+    /**
+     * Test scenario with FTP, username and password and default path
+     */
+    @Test
+    fun testFtpWithUsernamePasswordAndDefaultPath() {
+        doTestWithDialog(
+            arguments =
+                Bundle().also {
+                    it.putString(ARG_PROTOCOL, FTP_URI_PREFIX)
+                    it.putString(ARG_NAME, "FTP Connection")
+                    it.putString(ARG_ADDRESS, "127.0.0.1")
+                    it.putInt(ARG_PORT, 2121)
+                    it.putString(ARG_USERNAME, "root")
+                    it.putString(ARG_DEFAULT_PATH, "/root/Private")
+                    it.putString(
+                        ARG_PASSWORD,
+                        PasswordUtil.encryptPassword(
+                            AppConfig.getInstance(),
+                            "abcdefgh",
+                        ),
+                    )
+                    it.putBoolean(ARG_HAS_PASSWORD, true)
+                    it.putBoolean(ARG_EDIT, true)
+                },
+            withDialog = { sftpConnectDialog, materialDialog ->
+                assertNotNull(sftpConnectDialog.binding)
+                requireNotNull(sftpConnectDialog.binding).let { binding ->
+                    assertFalse(binding.chkFtpExplicitTls.isChecked)
+                    assertFalse(binding.chkFtpAnonymous.isChecked)
+                    assertEquals(2121, binding.portET.text.toString().toInt())
+                    assertEquals("root", binding.usernameET.text.toString())
+                    assertEquals("FTP Connection", binding.connectionET.text.toString())
+                    assertEquals(1, binding.protocolDropDown.selectedItemPosition)
+                    assertEquals("", binding.passwordET.text.toString())
+                    assertEquals("/root/Private", binding.defaultPathET.text.toString())
+                }
+            },
+        )
+    }
+
+    /**
+     * Test scenario with FTP, anonymous
+     */
+    @Test
+    fun testFtpWithAnonymous() {
+        doTestWithDialog(
+            arguments =
+                Bundle().also {
+                    it.putString(ARG_PROTOCOL, FTP_URI_PREFIX)
+                    it.putString(ARG_NAME, "FTP Connection")
+                    it.putString(ARG_ADDRESS, "127.0.0.1")
+                    it.putInt(ARG_PORT, 2121)
+                    it.putBoolean(ARG_HAS_PASSWORD, false)
+                    it.putBoolean(ARG_EDIT, true)
+                },
+            withDialog = { sftpConnectDialog, materialDialog ->
+                assertNotNull(sftpConnectDialog.binding)
+                requireNotNull(sftpConnectDialog.binding).let { binding ->
+                    assertFalse(binding.chkFtpExplicitTls.isChecked)
+                    assertTrue(binding.chkFtpAnonymous.isChecked)
+                    assertEquals(2121, binding.portET.text.toString().toInt())
+                    assertEquals("FTP Connection", binding.connectionET.text.toString())
+                    assertEquals(1, binding.protocolDropDown.selectedItemPosition)
+                    assertEquals("", binding.passwordET.text.toString())
+                }
+            },
+        )
+    }
+
+    /**
+     * Test scenario with FTP, username and password + explicit TLS option
+     */
+    @Test
+    fun testFtpWithUsernamePasswordAndExplicitTls() {
+        doTestWithDialog(
+            arguments =
+                Bundle().also {
+                    it.putString(ARG_PROTOCOL, FTP_URI_PREFIX)
+                    it.putString(ARG_NAME, "FTP Connection")
+                    it.putString(ARG_ADDRESS, "127.0.0.1")
+                    it.putInt(ARG_PORT, 2121)
+                    it.putString(ARG_USERNAME, "root")
+                    it.putString(
+                        ARG_PASSWORD,
+                        PasswordUtil.encryptPassword(
+                            AppConfig.getInstance(),
+                            "abcdefgh",
+                        ),
+                    )
+                    it.putBoolean(ARG_HAS_PASSWORD, true)
+                    it.putString(ARG_TLS, "explicit")
+                    it.putBoolean(ARG_EDIT, true)
+                },
+            withDialog = { sftpConnectDialog, materialDialog ->
+                assertNotNull(sftpConnectDialog.binding)
+                requireNotNull(sftpConnectDialog.binding).let { binding ->
+                    assertTrue(binding.chkFtpExplicitTls.isChecked)
+                    assertFalse(binding.chkFtpAnonymous.isChecked)
+                    assertEquals(2121, binding.portET.text.toString().toInt())
+                    assertEquals("root", binding.usernameET.text.toString())
+                    assertEquals("FTP Connection", binding.connectionET.text.toString())
+                    assertEquals(1, binding.protocolDropDown.selectedItemPosition)
+                    assertEquals("", binding.passwordET.text.toString())
+                }
+            },
+        )
+    }
+
+    /**
+     * Test scenario with FTP, username and password + explicit TLS option
+     */
+    @Test
+    fun testFtpWithUsernamePasswordAndExplicitTlsPlusDefaultPath() {
+        doTestWithDialog(
+            arguments =
+                Bundle().also {
+                    it.putString(ARG_PROTOCOL, FTP_URI_PREFIX)
+                    it.putString(ARG_NAME, "FTP Connection")
+                    it.putString(ARG_ADDRESS, "127.0.0.1")
+                    it.putInt(ARG_PORT, 2121)
+                    it.putString(ARG_USERNAME, "root")
+                    it.putString(
+                        ARG_PASSWORD,
+                        PasswordUtil.encryptPassword(
+                            AppConfig.getInstance(),
+                            "abcdefgh",
+                        ),
+                    )
+                    it.putString(ARG_DEFAULT_PATH, "/root/Documents")
+                    it.putBoolean(ARG_HAS_PASSWORD, true)
+                    it.putString(ARG_TLS, "explicit")
+                    it.putBoolean(ARG_EDIT, true)
+                },
+            withDialog = { sftpConnectDialog, materialDialog ->
+                assertNotNull(sftpConnectDialog.binding)
+                requireNotNull(sftpConnectDialog.binding).let { binding ->
+                    assertTrue(binding.chkFtpExplicitTls.isChecked)
+                    assertFalse(binding.chkFtpAnonymous.isChecked)
+                    assertEquals(2121, binding.portET.text.toString().toInt())
+                    assertEquals("root", binding.usernameET.text.toString())
+                    assertEquals("FTP Connection", binding.connectionET.text.toString())
+                    assertEquals(1, binding.protocolDropDown.selectedItemPosition)
+                    assertEquals("", binding.passwordET.text.toString())
+                    assertEquals("/root/Documents", binding.defaultPathET.text.toString())
+                }
+            },
+        )
+    }
+
+    /**
+     * Test scenario with FTP, anonymous and explicit TLS option
+     */
+    @Test
+    fun testFtpWithAnonymousWithExplicitTls() {
+        doTestWithDialog(
+            arguments =
+                Bundle().also {
+                    it.putString(ARG_PROTOCOL, FTP_URI_PREFIX)
+                    it.putString(ARG_NAME, "FTP Connection")
+                    it.putString(ARG_ADDRESS, "127.0.0.1")
+                    it.putInt(ARG_PORT, 2121)
+                    it.putBoolean(ARG_HAS_PASSWORD, false)
+                    it.putBoolean(ARG_EDIT, true)
+                    it.putString(ARG_TLS, "explicit")
+                },
+            withDialog = { sftpConnectDialog, materialDialog ->
+                assertNotNull(sftpConnectDialog.binding)
+                requireNotNull(sftpConnectDialog.binding).let { binding ->
+                    assertTrue(binding.chkFtpExplicitTls.isChecked)
+                    assertTrue(binding.chkFtpAnonymous.isChecked)
+                    assertEquals(2121, binding.portET.text.toString().toInt())
+                    assertEquals("FTP Connection", binding.connectionET.text.toString())
+                    assertEquals(1, binding.protocolDropDown.selectedItemPosition)
+                    assertEquals("", binding.passwordET.text.toString())
+                }
+            },
+        )
+    }
+
+    /**
+     * Test scenario with FTP, anonymous and explicit TLS option
+     */
+    @Test
+    fun testFtpWithAnonymousWithExplicitTlsAndDefaultPath() {
+        doTestWithDialog(
+            arguments =
+                Bundle().also {
+                    it.putString(ARG_PROTOCOL, FTP_URI_PREFIX)
+                    it.putString(ARG_NAME, "FTP Connection")
+                    it.putString(ARG_ADDRESS, "127.0.0.1")
+                    it.putInt(ARG_PORT, 2121)
+                    it.putBoolean(ARG_HAS_PASSWORD, false)
+                    it.putBoolean(ARG_EDIT, true)
+                    it.putString(ARG_TLS, "explicit")
+                    it.putString(ARG_DEFAULT_PATH, "/Incoming")
+                },
+            withDialog = { sftpConnectDialog, materialDialog ->
+                assertNotNull(sftpConnectDialog.binding)
+                requireNotNull(sftpConnectDialog.binding).let { binding ->
+                    assertTrue(binding.chkFtpExplicitTls.isChecked)
+                    assertTrue(binding.chkFtpAnonymous.isChecked)
+                    assertEquals(2121, binding.portET.text.toString().toInt())
+                    assertEquals("FTP Connection", binding.connectionET.text.toString())
+                    assertEquals(1, binding.protocolDropDown.selectedItemPosition)
+                    assertEquals("", binding.passwordET.text.toString())
+                    assertEquals("/Incoming", binding.defaultPathET.text.toString())
+                }
+            },
+        )
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialogFtpTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialogFtpTest.kt
@@ -1,0 +1,160 @@
+package com.amaze.filemanager.ui.dialogs
+
+import android.os.Bundle
+import android.util.Base64
+import androidx.test.core.app.ApplicationProvider
+import com.amaze.filemanager.filesystem.ftp.FTPClientImpl.Companion.ARG_TLS
+import com.amaze.filemanager.filesystem.ftp.FTPClientImpl.Companion.TLS_EXPLICIT
+import com.amaze.filemanager.filesystem.ftp.NetCopyClientUtils
+import com.amaze.filemanager.ui.activities.MainActivity
+import com.amaze.filemanager.ui.dialogs.SftpConnectDialog.Companion.ARG_PASSWORD
+import com.amaze.filemanager.ui.dialogs.SftpConnectDialog.Companion.ARG_USERNAME
+import com.amaze.filemanager.utils.PasswordUtil
+import org.awaitility.Awaitility.await
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doCallRealMethod
+import java.io.IOException
+import java.security.GeneralSecurityException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Test [SftpConnectDialog] with FTP(S) connections.
+ */
+@Suppress("StringLiteralDuplication")
+class SftpConnectDialogFtpTest : AbstractSftpConnectDialogTests() {
+    /**
+     * Test invoke [SftpConnectDialog] with arguments username and password.
+     */
+    @Test
+    fun testInvokeSftpConnectionDialog() {
+        val verify = Bundle()
+        verify.putString("address", "127.0.0.1")
+        verify.putInt("port", 2121)
+        verify.putString("name", "FTP Connection")
+        verify.putString("username", "root")
+        verify.putString("password", "abcdefgh")
+        verify.putBoolean("hasPassword", true)
+        verify.putBoolean("edit", true)
+
+        testOpenSftpConnectDialog("ftp://root:abcdefgh@127.0.0.1:2121", verify)
+    }
+
+    /**
+     * Test invoke [SftpConnectDialog] with arguments username and password and explicit TLS option
+     */
+    @Test
+    fun testInvokeSftpConnectionDialogWithExplicitTlsFlagEnabled() {
+        val verify = Bundle()
+        verify.putString("address", "127.0.0.1")
+        verify.putInt("port", 2121)
+        verify.putString("name", "FTP Connection")
+        verify.putString("username", "root")
+        verify.putString("password", "abcdefgh")
+        verify.putBoolean("hasPassword", true)
+        verify.putString("tls", "explicit")
+        verify.putBoolean("edit", true)
+
+        testOpenSftpConnectDialog(
+            "ftp://root:abcdefgh@127.0.0.1:2121?tls=explicit",
+            verify,
+            true,
+        )
+    }
+
+    /**
+     * Test invoke [SftpConnectDialog] without any arguments
+     */
+    @Test
+    fun testInvokeSftpConnectionDialogWithoutUsernamePassword() {
+        val verify = Bundle()
+        verify.putString("address", "127.0.0.1")
+        verify.putInt("port", 2121)
+        verify.putString("name", "FTP Connection")
+        verify.putBoolean("hasPassword", true)
+        verify.putBoolean("edit", true)
+
+        testOpenSftpConnectDialog(
+            "ftp://127.0.0.1:2121",
+            verify,
+            false,
+            true,
+        )
+    }
+
+    /**
+     * Test invoke [SftpConnectDialog] without username/password but with explicit TLS option
+     */
+    @Test
+    fun testInvokeSftpConnectionDialogWithoutUsernamePasswordAndExplicitTls() {
+        val verify = Bundle()
+        verify.putString("address", "127.0.0.1")
+        verify.putInt("port", 2121)
+        verify.putString("name", "FTP Connection")
+        verify.putBoolean("hasPassword", true)
+        verify.putString("tls", "explicit")
+        verify.putBoolean("edit", true)
+
+        testOpenSftpConnectDialog(
+            "ftp://127.0.0.1:2121?tls=explicit",
+            verify,
+            true,
+            true,
+        )
+    }
+
+    @Throws(GeneralSecurityException::class, IOException::class)
+    private fun testOpenSftpConnectDialog(
+        uri: String,
+        verify: Bundle,
+        explicitTls: Boolean = false,
+        anonymous: Boolean = false,
+    ): SftpConnectDialog {
+        val activity = mock(MainActivity::class.java)
+        doCallRealMethod().`when`(activity).showSftpDialog(
+            any(),
+            any(),
+            anyBoolean(),
+        )
+        activity.showSftpDialog(
+            "FTP Connection",
+            NetCopyClientUtils.encryptFtpPathAsNecessary(uri),
+            true,
+        )
+        assertEquals(1, mc.constructed().size)
+        val mocked = mc.constructed()[0]
+        await().atMost(10, TimeUnit.SECONDS).until { mocked.arguments != null }
+        mocked.arguments?.let { args ->
+            if (explicitTls) {
+                assertTrue(args.containsKey(ARG_TLS))
+                assertEquals(TLS_EXPLICIT, args.getString(ARG_TLS))
+            }
+            val keys = BUNDLE_KEYS.clone().toMutableList()
+            if (anonymous) {
+                keys.remove(ARG_USERNAME)
+                keys.remove(ARG_PASSWORD)
+            }
+            for (key in keys) {
+                if (args.getString(key) != null) {
+                    if (key == ARG_PASSWORD) {
+                        assertEquals(
+                            verify.getString(key),
+                            PasswordUtil.decryptPassword(
+                                ApplicationProvider.getApplicationContext(),
+                                args.getString(key)!!,
+                                Base64.URL_SAFE,
+                            ),
+                        )
+                    } else {
+                        assertEquals(verify.getString(key), args.getString(key))
+                    }
+                }
+            }
+        }
+        return mocked
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/utils/SmbUtilTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/utils/SmbUtilTest.kt
@@ -79,6 +79,20 @@ class SmbUtilTest {
     }
 
     /**
+     * Test encrypt/decrypt FTP(S) URIs.
+     */
+    @Test
+    fun testEncryptDecryptFtpsWithExtraParams() {
+        val path = "ftps://root:toor@127.0.0.1?tls=explicit"
+        val encrypted = getSmbEncryptedPath(ApplicationProvider.getApplicationContext(), path)
+        assertNotEquals(path, encrypted)
+        assertTrue(encrypted.startsWith("ftps://root:"))
+        assertTrue(encrypted.endsWith("@127.0.0.1?tls=explicit"))
+        val decrypted = getSmbDecryptedPath(ApplicationProvider.getApplicationContext(), encrypted)
+        assertEquals(path, decrypted)
+    }
+
+    /**
      * Test encrypt/decrypt URIs without username and password. It should stay the same.
      */
     @Test


### PR DESCRIPTION
## Description
Adds an Explicit TLS option at SftpConnectionDialog, and implement explicit TLS for FTPS.

#### Issue tracker   
Fixes #3656

#### Automatic tests
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 2 emulator
- OS: Android 7.1.1

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
