### PR TITLE
Increase DEFAULT_TRANSFER_QUANTUM to 1 MB

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/GenericCopyUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/GenericCopyUtil.java
@@ -72,8 +72,6 @@ public class GenericCopyUtil {
   private final DataUtils dataUtils = DataUtils.getInstance();
   private final ProgressHandler progressHandler;
 
-  public static final String PATH_FILE_DESCRIPTOR = "/proc/self/fd/";
-
   public static final int DEFAULT_BUFFER_SIZE = 8192;
 
   /*
@@ -82,7 +80,7 @@ public class GenericCopyUtil {
      Cannot modify DEFAULT_BUFFER_SIZE since it's used by other classes, will have undesired
      effect on other functions
   */
-  private static final int DEFAULT_TRANSFER_QUANTUM = 65536;
+  private static final int DEFAULT_TRANSFER_QUANTUM = 1024 * 1024;
 
   public GenericCopyUtil(Context context, ProgressHandler progressHandler) {
     this.mContext = context;


### PR DESCRIPTION
## Description

In an attempt to increase efficiency in file I/O, either local or network.

At the expense of small files, but should be just fine as
- active Android devices that Amaze would run can easily have GBs of memory
- files that Android devices carry in/out can easily take the whole megabyte buffer

#### Issue tracker   
Addresses #4170 

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [ ] Done  
  
- Device:
- OS:

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`