### PR TITLE
Files with ambiguous names crash on extraction : Fixed

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/CompressedHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/CompressedHelper.java
@@ -202,8 +202,9 @@ public abstract class CompressedHelper {
    */
   public static String getFileName(String compressedName) {
     compressedName = compressedName.toLowerCase();
-      boolean hasFileName = compressedName.contains(".");
-    if (hasFileName && (isZip(compressedName)
+    boolean hasFileName = compressedName.contains(".");
+    if (hasFileName
+        && (isZip(compressedName)
             || isTar(compressedName)
             || isRar(compressedName)
             || is7zip(compressedName)
@@ -218,9 +219,9 @@ public abstract class CompressedHelper {
             || isXz(compressedName))) {
       return compressedName.substring(0, compressedName.lastIndexOf("."));
     } else if (hasFileName && isGzippedTar(compressedName)
-            || isXzippedTar(compressedName)
-            || isLzippedTar(compressedName)
-            || isBzippedTar(compressedName)) {
+        || isXzippedTar(compressedName)
+        || isLzippedTar(compressedName)
+        || isBzippedTar(compressedName)) {
       return compressedName.substring(0, Utils.nthToLastCharIndex(2, compressedName, '.'));
     } else {
       return compressedName;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/compressed/CompressedHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/compressed/CompressedHelper.java
@@ -202,24 +202,25 @@ public abstract class CompressedHelper {
    */
   public static String getFileName(String compressedName) {
     compressedName = compressedName.toLowerCase();
-    if (isZip(compressedName)
-        || isTar(compressedName)
-        || isRar(compressedName)
-        || is7zip(compressedName)
-        || isXz(compressedName)
-        || isLzma(compressedName)
-        || isGzip(compressedName)
-        || compressedName.endsWith(fileExtensionGzipTarShort)
-        || compressedName.endsWith(fileExtensionBzip2TarShort)
-        || isGzip(compressedName)
-        || isBzip2(compressedName)
-        || isLzma(compressedName)
-        || isXz(compressedName)) {
+      boolean hasFileName = compressedName.contains(".");
+    if (hasFileName && (isZip(compressedName)
+            || isTar(compressedName)
+            || isRar(compressedName)
+            || is7zip(compressedName)
+            || isXz(compressedName)
+            || isLzma(compressedName)
+            || isGzip(compressedName)
+            || compressedName.endsWith(fileExtensionGzipTarShort)
+            || compressedName.endsWith(fileExtensionBzip2TarShort)
+            || isGzip(compressedName)
+            || isBzip2(compressedName)
+            || isLzma(compressedName)
+            || isXz(compressedName))) {
       return compressedName.substring(0, compressedName.lastIndexOf("."));
-    } else if (isGzippedTar(compressedName)
-        || isXzippedTar(compressedName)
-        || isLzippedTar(compressedName)
-        || isBzippedTar(compressedName)) {
+    } else if (hasFileName && isGzippedTar(compressedName)
+            || isXzippedTar(compressedName)
+            || isLzippedTar(compressedName)
+            || isBzippedTar(compressedName)) {
       return compressedName.substring(0, Utils.nthToLastCharIndex(2, compressedName, '.'));
     } else {
       return compressedName;


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
This crash issue is easily reproducible by renaming any file with one of "zip/tar/rar/7z" and clicking on `Extract` option for the same. This is happening because, as per the current code, every file having name ending with one of above is treated as a compressed file and `Extract` option is then enabled for it. On clicking the `Extract` the code tries to fetch the file name and the code then crashes as there is no filename present except for the extension itself.

```diff
+ boolean hasFileName = compressedName.contains(".");
```


#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
Fixes #4146 
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
<!-- If yes, -->
<!-- 
- Device: Poco F3 GT
- OS: Android 12
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->