### PR TITLE
Fix logging messages

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/loaders/AppListLoader.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/loaders/AppListLoader.java
@@ -84,7 +84,7 @@ public class AppListLoader extends AsyncTaskLoader<List<AppDataParcelable>> {
     try {
       androidInfo = packageManager.getPackageInfo("android", PackageManager.GET_SIGNATURES);
     } catch (PackageManager.NameNotFoundException e) {
-      LOG.warn("faield to find android package name while loading apps list", e);
+      LOG.warn("failed to find android package name while loading apps list", e);
     }
 
     for (ApplicationInfo object : apps) {
@@ -99,7 +99,7 @@ public class AppListLoader extends AsyncTaskLoader<List<AppDataParcelable>> {
       try {
         info = packageManager.getPackageInfo(object.packageName, PackageManager.GET_SIGNATURES);
       } catch (PackageManager.NameNotFoundException e) {
-        LOG.warn("faield to find package name {} while loading apps list", object.packageName, e);
+        LOG.warn("failed to find package name {} while loading apps list", object.packageName, e);
         info = null;
       }
       boolean isSystemApp = isAppInSystemPartition(object) || isSignedBySystem(info, androidInfo);

--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -1017,9 +1017,9 @@ public class FileUtils {
     }
     File pathFile = new File(uri.getPath().substring(FILE_PROVIDER_PREFIX.length() + 1));
     if (!pathFile.exists()) {
-      LOG.warn("failed to navigate to path {}", pathFile.getPath());
+      LOG.warn("Failed to navigate to the initial path: {}", pathFile.getPath());
       pathFile = new File(uri.getPath());
-      LOG.warn("trying to navigate to path {}", pathFile.getPath());
+      LOG.warn("Attempting to navigate to the fallback path: {}", pathFile.getPath());
     }
     return pathFile;
   }


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

#### Description
This pull request addresses the issues with the logging statements in the `fromContentUri` method. The changes improve the clarity and context of the log messages when navigating to file paths.

The original code is confusing to understand.
```java
File pathFile = new File(uri.getPath().substring(FILE_PROVIDER_PREFIX.length() + 1));
    if (!pathFile.exists()) {
      LOG.warn("failed to navigate to path {}", pathFile.getPath());
      pathFile = new File(uri.getPath());
      LOG.warn("trying to navigate to path {}", pathFile.getPath());
    }
    return pathFile;
```

#### Changes:
1. **Initial Path Navigation Failure Log**:
    - Original: 
      ```java
      LOG.warn("failed to navigate to path {}", pathFile.getPath());
      ```
    - Improved: 
      ```java
      LOG.warn("Failed to navigate to the initial path: {}", pathFile.getPath());
      ```
    - **Reason**: Provides more context by indicating that this is the **initial** path navigation attempt.

2. **Fallback Path Navigation Log**:
    - Original: 
      ```java
      LOG.warn("trying to navigate to path {}", pathFile.getPath());
      ```
    - Improved: 
      ```java
      LOG.warn("Attempting to navigate to the fallback path: {}", pathFile.getPath());
    - **Reason**: Clarifies that this is a second attempt to navigate to a fallback path.

These improvements will help in better understanding and diagnosing issues related to file path navigation failures.


#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [ ] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [ ] `./gradlew assembledebug`
- [ ] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->