### PR TITLE
chore: uprade kotlin to 1.9.25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 
 plugins {
     id "com.diffplug.spotless" version "6.25.0"
-    id "com.google.devtools.ksp" version "1.9.10-1.0.13" apply false
+    id "com.google.devtools.ksp" version "1.9.25-1.0.20" apply false
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 compileSdk = "34"
 minSdk = "21"
 targetSdk = "34"
-kotlin = "1.9.10"
+kotlin = "1.9.25"
 
 jacocoAndroid = "0.2.1"
 gradle = "8.5.2"


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
This will make it build under jdk 21.

```
./gradlew assemblefdroidRelease

* What went wrong:
Could not determine the dependencies of task ':commons_compress_7z:compileReleaseKotlin'.
> Unknown Kotlin JVM target: 21
```

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
<!-- Fixes # -->
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->
