### PR TITLE
Add back foregroundServiceType="dataSync" to FtpService

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -280,6 +280,7 @@
             android:name=".asynchronous.services.ftp.FtpService"
             android:enabled="true"
             android:exported="true"
+            android:foregroundServiceType="dataSync"
             android:permission="${applicationId}.permission.CONTROL_FTP_SERVER" />
 
         <service android:name=".asynchronous.services.ftp.FtpTileService"


### PR DESCRIPTION
## Description

To fix crash when starting FtpService by declaring `foregroundServiceType="dataSync"`

#### Issue tracker   
Fixes #4377

#### Manual tests
- [x] Done  
  
- Pixel 3 emulator running stock Android 9
- Pixel 7 emulator running stock Android 15
Both devices could start FtpService from the FtpServerFragment or through tile without crashing the app.

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`