### PR TITLE
Add guard against invalid port numbers passed into NetCopyConnectionInfo

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/ftp/NetCopyConnectionInfo.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ftp/NetCopyConnectionInfo.kt
@@ -25,6 +25,8 @@ import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.FTP_URI_
 import com.amaze.filemanager.filesystem.ftp.NetCopyClientConnectionPool.SSH_URI_PREFIX
 import com.amaze.filemanager.filesystem.ftp.NetCopyConnectionInfo.Companion.COLON
 import com.amaze.filemanager.filesystem.smb.CifsContexts.SMB_URI_PREFIX
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * Container object for SSH/FTP/FTPS URL, encapsulating logic for splitting information from given
@@ -58,6 +60,9 @@ class NetCopyConnectionInfo(url: String) {
         private set
 
     companion object {
+        @JvmStatic
+        private val LOGGER: Logger = LoggerFactory.getLogger(NetCopyConnectionInfo::class.java)
+
         // Regex taken from https://blog.stevenlevithan.com/archives/parseuri
         // (No, don't break it down to lines)
 
@@ -104,7 +109,12 @@ class NetCopyConnectionInfo(url: String) {
                      * Invalid string would have been trapped to other branches. Strings fell into
                      * this branch must be integer
                      */
-                        it[7].toInt()
+                        try {
+                            it[7].toInt()
+                        } catch (e: NumberFormatException) {
+                            LOGGER.warn("Unable to parse port number: ${it[7]}", e)
+                            0
+                        }
                     } else {
                         0
                     }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ftp/NetCopyConnectionInfo.kt
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ftp/NetCopyConnectionInfo.kt
@@ -110,7 +110,13 @@ class NetCopyConnectionInfo(url: String) {
                      * this branch must be integer
                      */
                         try {
-                            it[7].toInt()
+                            // Need to make sure port number is in range
+                            if (it[7].toInt() in 1..65535) {
+                                it[7].toInt()
+                            } else {
+                                LOGGER.warn("Port number is out of range: ${it[7]}")
+                                0
+                            }
                         } catch (e: NumberFormatException) {
                             LOGGER.warn("Unable to parse port number: ${it[7]}", e)
                             0

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ftp/NetCopyConnectionInfoTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ftp/NetCopyConnectionInfoTest.kt
@@ -334,4 +334,26 @@ class NetCopyConnectionInfoTest {
             assertEquals("test.log", this.lastPathSegment())
         }
     }
+
+    /**
+     * Test parsing invalid port number.
+     */
+    @Test
+    fun testParseInvalidPortNumber() {
+        NetCopyConnectionInfo("ssh://user:pass@127.0.0.1:22/a/b/c/d/e").run {
+            assertEquals(22, this.port)
+        }
+        NetCopyConnectionInfo("ssh://user:pass@127.0.0.1:21097/a/b/c/d/e").run {
+            assertEquals(21097, this.port)
+        }
+        NetCopyConnectionInfo("ssh://user:pass@127.0.0.1/a/b/c/d/e").run {
+            assertEquals(0, this.port)
+        }
+        NetCopyConnectionInfo("ssh://user:pass@127.0.0.1:2109775003564/a/b/c/d/e").run {
+            assertEquals(0, this.port)
+        }
+        NetCopyConnectionInfo("ssh://user:pass@127.0.0.1:${Long.MAX_VALUE}/a/b/c/d/e").run {
+            assertEquals(0, this.port)
+        }
+    }
 }

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ftp/NetCopyConnectionInfoTest.kt
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ftp/NetCopyConnectionInfoTest.kt
@@ -346,6 +346,9 @@ class NetCopyConnectionInfoTest {
         NetCopyConnectionInfo("ssh://user:pass@127.0.0.1:21097/a/b/c/d/e").run {
             assertEquals(21097, this.port)
         }
+        NetCopyConnectionInfo("ssh://user:pass@127.0.0.1:99999/a/b/c/d/e").run {
+            assertEquals(0, this.port)
+        }
         NetCopyConnectionInfo("ssh://user:pass@127.0.0.1/a/b/c/d/e").run {
             assertEquals(0, this.port)
         }


### PR DESCRIPTION
## Description
Add guard against invalid Integers as port number passed into NetCopyConnectionInfo.

#### Issue tracker   
Fixes #4362

#### Automatic tests
- [x] Added test cases
  
#### Manual tests
- [ ] Done  
  
#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`