### PR TITLE
Guard against NPE in SmbDeviceScannerObservable

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/utils/smb/SmbDeviceScannerObservable.kt
+++ b/app/src/main/java/com/amaze/filemanager/utils/smb/SmbDeviceScannerObservable.kt
@@ -26,6 +26,7 @@ import com.amaze.filemanager.utils.smb.SmbDeviceScannerObservable.DiscoverDevice
 import io.reactivex.Observable
 import io.reactivex.Observer
 import io.reactivex.disposables.Disposable
+import io.reactivex.disposables.Disposables
 import io.reactivex.schedulers.Schedulers
 import java.net.InetAddress
 
@@ -50,7 +51,7 @@ class SmbDeviceScannerObservable : Observable<ComputerParcelable>() {
         fun onCancel()
     }
 
-    var discoverDeviceStrategies: Array<DiscoverDeviceStrategy> =
+    private var discoverDeviceStrategies: Array<DiscoverDeviceStrategy> =
         arrayOf(
             WsddDiscoverDeviceStrategy(),
             SameSubnetDiscoverDeviceStrategy(),
@@ -61,7 +62,7 @@ class SmbDeviceScannerObservable : Observable<ComputerParcelable>() {
 
     private lateinit var observer: Observer<in ComputerParcelable>
 
-    private lateinit var disposable: Disposable
+    private var disposable: Disposable = Disposables.empty()
 
     /**
      * Stop discovering hosts. Notify containing strategies to stop, then stop the created
@@ -70,6 +71,9 @@ class SmbDeviceScannerObservable : Observable<ComputerParcelable>() {
     fun stop() {
         if (!disposable.isDisposed) {
             disposable.dispose()
+        }
+        discoverDeviceStrategies.forEach { strategy ->
+            strategy.onCancel()
         }
         observer.onComplete()
     }


### PR DESCRIPTION
## Description

Added empty Disposable to prevent NPE when SMB search dialog cancels and re-created.

Also added explicit DiscoverDeviceStrategy.onCancel() call when SmbDeviceScannerObservable.stop()s.

#### Issue tracker   
Fixes #4299

#### Manual tests
- [x] Done  
  
Device: Pixel 7 emulator running stock Android 14

1. Tap the Plus sign at the bottom right
2. Create new SMB connection
3. The SMB search dialog pops up
4. Press cancel
5. Create new SMB connection again
6. The SMB search dialog pops up again
7. App should not crash at this point

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

#### Related PR  
Related to PR #4372 - may require this PR for bug-free SMB device discovery experience.