### PR TITLE
Integrate the settings for file deletion into a single subsection

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -851,5 +851,6 @@ You only need to do this once, until the next time you select a new location for
     <string name="trash_bin_retention_bytes_summary">Maximum data (in MBs) trash bin can store</string>
     <string name="trash_bin_cleanup_interval_title">Cleanup interval</string>
     <string name="trash_bin_cleanup_interval_summary">Trigger auto-cleanup interval (hours)</string>
+    <string name="file_deletion">File Deletion</string>
 </resources>
 

--- a/app/src/main/res/xml/behavior_prefs.xml
+++ b/app/src/main/res/xml/behavior_prefs.xml
@@ -23,20 +23,6 @@
         app:key="texteditor_newstack"
         app:summary="@string/preference_newstack_summary"
         app:title="@string/preference_newstack_title" />
-    <com.amaze.filemanager.ui.views.preference.CheckBox
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:defaultValue="true"
-        app:key="delete_confirmation"
-        app:summary="@string/preference_delete_confirmation_summary"
-        app:title="@string/preference_delete_confirmation" />
-    <com.amaze.filemanager.ui.views.preference.CheckBox
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:defaultValue="false"
-        app:key="delete_permanently_without_confirmation"
-        app:summary="@string/preference_delete_permanently_without_confirmation_summary"
-        app:title="@string/preference_delete_permanently_without_confirmation" />
     <Preference
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -55,7 +41,7 @@
         app:key="extractpath"
         app:summary="@string/archive_summary"
         app:title="@string/archive_extract_folder"></Preference>
-    <PreferenceCategory android:title="@string/trash_bin">
+    <PreferenceCategory android:title="@string/file_deletion">
         <Preference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -80,6 +66,17 @@
             app:key="cleanup_interval"
             app:summary="@string/trash_bin_cleanup_interval_summary"
             app:title="@string/trash_bin_cleanup_interval_title"></Preference>
+        <com.amaze.filemanager.ui.views.preference.CheckBox
+            app:defaultValue="true"
+            app:key="delete_confirmation"
+            app:summary="@string/preference_delete_confirmation_summary"
+            app:title="@string/preference_delete_confirmation" />
+
+        <com.amaze.filemanager.ui.views.preference.CheckBox
+            app:defaultValue="false"
+            app:key="delete_permanently_without_confirmation"
+            app:summary="@string/preference_delete_permanently_without_confirmation_summary"
+            app:title="@string/preference_delete_permanently_without_confirmation" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/advanced_search">
 


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description
This PR reorganises the settings UI by grouping all file deletion-related options into a single section.  I renamed 'Trash bin' to 'File Deletion'.
Previously, the **Delete confirmation** and **Delete permanently without confirmation** settings were listed near the top, while other related options were under the Trash bin section.

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
Fixes #4401 


#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- Only XML layout changes; no logic affected
  
#### Manual tests
- [x] Done  

### Screenshot

<img src="https://github.com/user-attachments/assets/445351d2-7b6f-4457-94ab-f3f8de5aa228" width=300/>  

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
