### PR TITLE
transifex.yml: add Fastlane descriptions to be translatable

### DIFF
--- a/transifex.yml
+++ b/transifex.yml
@@ -6,6 +6,16 @@ filters:
     source_file: app/src/main/res/values/strings.xml
     # path expression to translation files, must contain <lang> placeholder
     translation_files_expression: app/src/main/res/values-<lang>/strings.xml
+  - filter_type: file
+    file_format: TXT
+    source_language: en_US
+    source_file: fastlane/metadata/android/en-US/full_description.txt
+    translation_files_expression: fastlane/metadata/android/<lang>/short_description.txt
+  - filter_type: file
+    file_format: TXT
+    source_language: en_US
+    source_file: fastlane/metadata/android/en-US/full_description.txt
+    translation_files_expression: fastlane/metadata/android/<lang>/short_description.txt
 settings:
   language_mapping:
     sv_SE: sv

--- a/transifex.yml
+++ b/transifex.yml
@@ -9,13 +9,13 @@ filters:
   - filter_type: file
     file_format: TXT
     source_language: en_US
-    source_file: fastlane/metadata/android/en-US/full_description.txt
+    source_file: fastlane/metadata/android/en-US/short_description.txt
     translation_files_expression: fastlane/metadata/android/<lang>/short_description.txt
   - filter_type: file
     file_format: TXT
     source_language: en_US
     source_file: fastlane/metadata/android/en-US/full_description.txt
-    translation_files_expression: fastlane/metadata/android/<lang>/short_description.txt
+    translation_files_expression: fastlane/metadata/android/<lang>/full_description.txt
 settings:
   language_mapping:
     sv_SE: sv


### PR DESCRIPTION
The app store descriptions are also needs to be translated.

Fixes #4411
