### PR TITLE
Fixed build dependency issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         glideVersion = '4.11.0'
         sshjVersion = '0.34.0'
         jcifsVersion = '2.1.6'
-        fabSpeedDialVersion = '3.1.1'
+        fabSpeedDialVersion = '3.3.0'
         roomVersion = '2.4.3'
         bouncyCastleVersion = '1.70'
         awaitilityVersion = "3.1.6"
@@ -62,6 +62,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+	maven { url 'https://repository.liferay.com/nexus/content/repositories/public/' }
         maven { url "https://jitpack.io" }
         maven { url "https://jcenter.bintray.com" }
     }


### PR DESCRIPTION
Note: There are some dependency issues in tag v3.8.4, and thus the gradlew build won't work. Particularly,

1. com.leinardi.android:speed-dial:3.1.1
* Fixed by changing to version 3.3.0 which is backward compatible.
2. com.github.pengrad:jdk9-deps:1.0
* Fixed by adding a repository maven { url 'https://repository.liferay.com/nexus/content/repositories/public/' }