### PR TITLE
Adaptations to enable 16KB page size support

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
+      - name: Set up NDK
+        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
+        with:
+          ndk-version: r28c
+          link-to-sdk: true
+          local-cache: true
       - name: Check formatting using spotless
         uses: gradle/actions/setup-gradle@v3
         with:

--- a/.github/workflows/android-debug-artifact-ondemand.yml
+++ b/.github/workflows/android-debug-artifact-ondemand.yml
@@ -40,6 +40,12 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
+      - name: Set up NDK
+        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
+        with:
+          ndk-version: r28c
+          link-to-sdk: true
+          local-cache: true
       - name: Build with Gradle
         uses: gradle/actions/setup-gradle@v3
         with:

--- a/.github/workflows/android-debug-artifact-release.yml
+++ b/.github/workflows/android-debug-artifact-release.yml
@@ -14,6 +14,12 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
+      - name: Set up NDK
+        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
+        with:
+          ndk-version: r28c
+          link-to-sdk: true
+          local-cache: true
       - name: Build with Gradle
         uses: gradle/actions/setup-gradle@v3
         with:

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
+      - name: Set up NDK
+        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
+        with:
+          ndk-version: r28c
+          link-to-sdk: true
+          local-cache: true
       - name: Check formatting using spotless
         uses: gradle/actions/setup-gradle@v3
         with:

--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
+      - name: Set up NDK
+        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
+        with:
+          ndk-version: r28c
+          link-to-sdk: true
+          local-cache: true
       - name: Check formatting using spotless
         uses: gradle/actions/setup-gradle@v3
         with:

--- a/file_operations/build.gradle
+++ b/file_operations/build.gradle
@@ -8,6 +8,7 @@ android {
 
     defaultConfig {
         minSdkVersion libs.versions.minSdk.get().toInteger()
+        ndkVersion libs.versions.ndk.get()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/file_operations/src/main/c/CMakeLists.txt
+++ b/file_operations/src/main/c/CMakeLists.txt
@@ -10,3 +10,4 @@ add_library(rootoperations SHARED rootoperations.c)
 find_library(log-lib log)
 
 target_link_libraries(rootoperations ${log-lib})
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "-Wl,-z,max-page-size=16384")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ compileSdk = "34"
 minSdk = "21"
 targetSdk = "34"
 kotlin = "1.9.25"
+ndk = "28.2.13676358"
 
 jacocoAndroid = "0.2.1"
 gradle = "8.5.2"


### PR DESCRIPTION
## Description
In response to [Google Play's notice](https://developer.android.com/guide/practices/page-sizes) for supporting 16KB devices.

- Forcing use of NDK 28c (if applicable)
- CMakeLists.txt add linker flag to force page size of 16KB
- Added setup NDK step in Github Actions workflow to force use of NDK 28c, borrowed from #4431

#### Manual tests
- [ ] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`