### PR TITLE
fix: selected item is unselected after clicking 'Select All' when there is only one item in the directory

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/selection/SelectionPopupMenu.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/selection/SelectionPopupMenu.kt
@@ -84,11 +84,12 @@ class SelectionPopupMenu(
         when (item?.itemId) {
             R.id.select_all -> {
                 // select_all
-                recyclerAdapter.toggleChecked(
-                    !recyclerAdapter
-                        .areAllChecked(currentPath),
-                    currentPath,
-                )
+                if (!recyclerAdapter.areAllChecked(currentPath)) {
+                    recyclerAdapter.toggleChecked(
+                        true,
+                        currentPath,
+                    )
+                }
             }
             R.id.select_inverse -> {
                 recyclerAdapter.toggleInverse(currentPath)


### PR DESCRIPTION
fixes #4327

Describe the bug
When there is only one item in the Trash Bin, the selected item is cancelled after clicking 'Select All'

To Reproduce
Steps to reproduce the behavior:

Click on 'Hamburger' menu
Click on 'Trash Bin'
Long press to select an item
Click on 'v' icon
Click on 'Select All'
Expected behavior
The selected item should remain selected after clicking ‘Select All’, even if it is the only item in the Trash Bin

Test Case scenarios's checked:
1. Selected single file and clicked on 'Selected All'. The item is still selected.
2. Selected a few and clicked 'Selected All'. Now, all the items are selected.

Device: Samsung Galaxy S24 (SM-S921W).