### PR TITLE
Fix the whitespace around filename or extension causes false negative

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/files/FileUtils.java
@@ -968,8 +968,20 @@ public class FileUtils {
 
   /** Convenience method to return if a path points to a compressed file. */
   public static boolean isCompressedFile(String path) {
-    @Nullable String extension = MimeTypes.getExtension(path);
-    return ArraysKt.indexOf(COMPRESSED_FILE_EXTENSIONS, extension) > -1;
+    if (path == null) return false;
+
+    // Normalize input: trim leading/trailing whitespace first
+    String normalizedPath = path.trim();
+    if (normalizedPath.isEmpty()) return false;
+
+    // Extract extension using MimeTypes helper, then normalize it
+    String extension = MimeTypes.getExtension(normalizedPath);
+    if (!extension.isEmpty()) {
+      extension = extension.trim().toLowerCase(Locale.getDefault());
+      return ArraysKt.indexOf(COMPRESSED_FILE_EXTENSIONS, extension) > -1;
+    }
+
+    return false;
   }
 
   /** Converts ArrayList of HybridFileParcelable to ArrayList of File */


### PR DESCRIPTION
## Description

1. Fix incorrect detection of compressed files when filenames contain whitespace
2. Add a MIME-type fallback for files with missing or malformed extensions

#### Issue tracker   

Fixes #4478

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [ ] Done  

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`