### PR TITLE
Add Save as option for VIEW intents with content:// URIs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -132,6 +132,12 @@
                 <data android:mimeType="*/*" />
             </intent-filter>
 
+            <intent-filter android:label="@string/intent_save_as" tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" android:mimeType="*/*" />
+            </intent-filter>
+
             <meta-data android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
         </activity>

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -639,6 +639,15 @@ public class MainActivity extends PermissionsActivity
          * http://teamamaze.xyz/open_file?path=path-to-file
          */
         path = Utils.sanitizeInput(uri.getQueryParameter("path"));
+      } else if (uri != null && ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
+        // save a single file to filesystem
+        List<Uri> uris = new ArrayList<>();
+        uris.add(uri);
+        showSaveSnackbar(uris);
+
+        // disable screen rotation just for convenience purpose
+        // TODO: Support screen rotation when saving a file
+        Utils.disableScreenRotation(this);
       } else {
         LOG.warn(getString(R.string.error_cannot_find_way_open));
       }


### PR DESCRIPTION
## Description

Adds "Save as" option when opening files via VIEW intent with content:// URIs.

Previously, when apps like Mattermost send a VIEW intent for a single file, users only saw "Amaze Document Viewer" which just prompts to download File Utilities. Now users will also see "Save as" option that triggers the existing save flow.

#### Automatic tests
- [ ] Added test cases

#### Manual tests
- [x] Done

- Device: Nothing Phone 2
- OS: Android 16

#### Build tasks success
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`