### PR TITLE
Chore: Wordings change for SmbConnectDialog

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbSearchDialog.kt
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SmbSearchDialog.kt
@@ -93,7 +93,7 @@ class SmbSearchDialog : DialogFragment() {
                 mainActivity.showSMBDialog("", "", false)
             }
         }
-        builder.positiveText(R.string.use_custom_ip)
+        builder.positiveText(R.string.smb_manual_enter_host)
         builder.positiveColor(accentColor)
         viewModel.valHolder.postValue(ComputerParcelable("-1", "-1"))
         listViewAdapter = ListViewAdapter(requireActivity())

--- a/app/src/main/res/layout/smb_dialog.xml
+++ b/app/src/main/res/layout/smb_dialog.xml
@@ -29,7 +29,7 @@
             android:layout_height="wrap_content"
             android:ems="10"
             android:inputType="textUri"
-            android:hint="@string/server_address"
+            android:hint="@string/smb_server"
             android:id="@+id/ipET"
             android:layout_gravity="center_horizontal" />
     </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -315,7 +315,6 @@
     <string name="translate_summary">ترجمة العز باللغة الخاصة بك </string>
     <string name="paypal_copy_message">تم نسخ كود PayPal الى المسودة </string>
     <string name="searching_devices">البحث عن أجهزة </string>
-    <string name="use_custom_ip">استخدام IP المهيأ </string>
     <string name="bookmark_lost">لم يتم ايجاد علامة التوقف ، قم باعادة التكوين ... </string>
 
     <string name="share_limit">لا يمكن مشاركة أكثر من 100 ملف </string>

--- a/app/src/main/res/values-ast-rES/strings.xml
+++ b/app/src/main/res/values-ast-rES/strings.xml
@@ -302,7 +302,6 @@ inestable\'l preséu.\\n¿Siguir?</string>
     <string name="translate_summary">Torna Amaze a la to llingua</string>
     <string name="paypal_copy_message">Copióse la ID de Paypal nel cartafueyu</string>
     <string name="searching_devices">Guetando preseos</string>
-    <string name="use_custom_ip">Usar IP personalizada</string>
     <string name="bookmark_lost">Nun s\'alcontró\'l marcador, recreando&#8230;</string>
 
     <string name="share_limit">Nun pues compartir más de 100 ficheros</string>

--- a/app/src/main/res/values-be-rBY/strings.xml
+++ b/app/src/main/res/values-be-rBY/strings.xml
@@ -299,8 +299,7 @@
   <string name="easter_egg_title">Рэжым Студыі</string>
   <string name="paypal_copy_message">PayPal id скапіявана ў буфер абмену</string>
   <string name="searching_devices">Пошук прылад</string>
-  <string name="use_custom_ip">Выкарыстоўваць карыстацкую IP</string>
-  <string name="bookmark_lost">Закладкі не знойдзены, паўторна стварыць&#8230;</string>
+    <string name="bookmark_lost">Закладкі не знойдзены, паўторна стварыць&#8230;</string>
 
   <string name="share_limit">Немагчыма абменьвацца больш за 100 файлаў</string>
   <string name="otg_access">Выберыце каранёвую тэчку OTG прылады</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -318,7 +318,6 @@
     <string name="translate_summary">Přeložte Amaze do vašeho jazyka</string>
     <string name="paypal_copy_message">Paypal ID bylo zkopírováno do schránky</string>
     <string name="searching_devices">Vyhledávání zařízení</string>
-    <string name="use_custom_ip">Použít vlastní IP</string>
     <string name="bookmark_lost">Záložka nebyla nalezena, obnovování&#8230;</string>
 
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -324,7 +324,6 @@ andernfalls wird nach Treffern gesucht.</string>
     <string name="translate_summary">Amaze in Ihre Sprache übersetzen</string>
     <string name="paypal_copy_message">PayPal-ID in die Zwischenablage kopiert</string>
     <string name="searching_devices">Suche nach Geräten</string>
-    <string name="use_custom_ip">Benutzerdefinierte IP verwenden</string>
     <string name="bookmark_lost">Lesezeichen nicht gefunden, erstelle erneut&#8230;</string>
 
     <string name="share_limit">Es können nicht mehr als 100 Dateien geteilt werden</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -319,7 +319,6 @@
     <string name="translate_summary">Μετάφραση του Amaze στη γλώσσα σας</string>
     <string name="paypal_copy_message">Το PayPal ID αντιγράφηκε στο πρόχειρο</string>
     <string name="searching_devices">Αναζήτηση συσκευών</string>
-    <string name="use_custom_ip">Χρήση προσαρμοσμένης IP</string>
     <string name="bookmark_lost">Δεν βρέθηκε σελιδοδείκτης, επαναδημιουργία&#8230;</string>
 
     <string name="share_limit">Αδύνατη η κοινή χρήση περισσότερων από 100 αρχείων</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -309,7 +309,6 @@
     <string name="translate_summary">Traduki Amaze en via lingvo</string>
     <string name="paypal_copy_message">PayPal ID kopiita al poŝo</string>
     <string name="searching_devices">Serĉanta aparatojn</string>
-    <string name="use_custom_ip">Uzi propan IP-adreson</string>
     <string name="bookmark_lost">Legosigno ne trovita, rekreinta&#8230;</string>
 
     <string name="share_limit">Ne povas kunhavigin pli da 100 dosieroj</string>

--- a/app/src/main/res/values-es-rCO/strings.xml
+++ b/app/src/main/res/values-es-rCO/strings.xml
@@ -293,8 +293,7 @@
   <string name="easter_egg_title">Modo de estudio</string>
   <string name="paypal_copy_message">Id de Paypal copiado al portapapeles</string>
   <string name="searching_devices">Buscando dispositivos</string>
-  <string name="use_custom_ip">Utilizar IP personalizada</string>
-  <string name="bookmark_lost">Marcador no encontrado, recreando&#8230;</string>
+    <string name="bookmark_lost">Marcador no encontrado, recreando&#8230;</string>
   <string name="share_limit">No se pueden compartir más de 100 archivos</string>
   <string name="otg_access">Seleccione la raíz del dispositivo OTG</string>
   <string name="opening">Abriendo...</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -293,8 +293,7 @@
   <string name="easter_egg_title">Modo de estudio</string>
   <string name="paypal_copy_message">Id de Paypal copiado al portapapeles</string>
   <string name="searching_devices">Buscando dispositivos</string>
-  <string name="use_custom_ip">Utilizar IP personalizada</string>
-  <string name="bookmark_lost">Marcador no encontrado, recreando&#8230;</string>
+    <string name="bookmark_lost">Marcador no encontrado, recreando&#8230;</string>
   <string name="share_limit">No se pueden compartir más de 100 archivos</string>
   <string name="otg_access">Seleccione la raíz del dispositivo OTG</string>
   <string name="opening">Abriendo...</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -299,8 +299,7 @@
   <string name="easter_egg_title">Modo de estudio</string>
   <string name="paypal_copy_message">Id de Paypal copiado al portapapeles</string>
   <string name="searching_devices">Buscando dispositivos</string>
-  <string name="use_custom_ip">Utilizar IP personalizada</string>
-  <string name="bookmark_lost">Marcador no encontrado, recreando&#8230;</string>
+    <string name="bookmark_lost">Marcador no encontrado, recreando&#8230;</string>
   <string name="share_limit">No se pueden compartir más de 100 archivos</string>
   <string name="otg_access">Seleccione la raíz del dispositivo OTG</string>
   <string name="opening">Abriendo...</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -315,7 +315,6 @@
     <string name="translate_summary">Traducir Amaze a tu idioma</string>
     <string name="paypal_copy_message">Id de Paypal copiado al portapapeles</string>
     <string name="searching_devices">Buscando dispositivos</string>
-    <string name="use_custom_ip">Utilizar IP personalizada</string>
     <string name="bookmark_lost">Marcador no encontrado, recreando&#8230;</string>
 
     <string name="share_limit">No se pueden compartir más de 100 archivos</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -312,7 +312,6 @@
   <string name="easter_egg_title">Studio modua</string>
     <string name="paypal_copy_message">Paypal id-a arbelera kopiatu da</string>
     <string name="searching_devices">Gailuak bilatzen</string>
-    <string name="use_custom_ip">Erabili IP pertsonalizatua</string>
     <string name="bookmark_lost">Ez da laster-marka aurkitu, birsortzen&#8230;</string>
 
     <string name="share_limit">Ezin dira 100 fitxategi baino gehiago partekatu</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -311,7 +311,6 @@
     <string name="translate_summary">Itzuli Amaze zure hizkuntzara</string>
     <string name="paypal_copy_message">Paypal id-a arbelera kopiatu da</string>
     <string name="searching_devices">Gailuak bilatzen</string>
-    <string name="use_custom_ip">Erabili IP pertsonalizatua</string>
     <string name="bookmark_lost">Ez da laster-marka aurkitu, birsortzen&#8230;</string>
 
     <string name="share_limit">Ezin dira 100 fitxategi baino gehiago partekatu</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -301,7 +301,6 @@
     <string name="translate_summary">Käännä Amaze omalle kielelle</string>
     <string name="paypal_copy_message">PayPal-tunnus kopioitu leikepöydälle</string>
     <string name="searching_devices">Etsitään laitteita</string>
-    <string name="use_custom_ip">Käytä mukautettu IP-osoitetta</string>
     <string name="bookmark_lost">Kirjanmerkkiä ei löydy, luodaan uudestaan&#8230;</string>
 
     <string name="share_limit">Ei voi jakaa yli 100 tiedostoa</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -302,8 +302,7 @@
   <string name="easter_egg_title">Mode Studio</string>
   <string name="paypal_copy_message">Id Paypal copié dans le presse-papiers</string>
   <string name="searching_devices">Recherche d\'appareils</string>
-  <string name="use_custom_ip">Utiliser une adresse IP modifiée</string>
-  <string name="bookmark_lost">Favori non trouvé, recréation&#8230;</string>
+    <string name="bookmark_lost">Favori non trouvé, recréation&#8230;</string>
 
   <string name="share_limit">Impossible de partage plus de 100 fichiers</string>
   <string name="otg_access">Sélectionnez le root du périphérique OTG</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -322,7 +322,6 @@
     <string name="translate_summary">Traduire Amaze dans votre langue</string>
     <string name="paypal_copy_message">Id Paypal copié dans le presse-papiers</string>
     <string name="searching_devices">Recherche d\'appareils</string>
-    <string name="use_custom_ip">Utiliser une adresse IP modifiée</string>
     <string name="bookmark_lost">Favori non trouvé, reconstitution en cours&#8230;</string>
 
     <string name="share_limit">Impossible de partage plus de 100 fichiers</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -323,7 +323,6 @@
     <string name="translate_summary">תרגום Amaze לשפה שלך</string>
     <string name="paypal_copy_message">מזהה ה־PayPal הועתק ללוח הגזירים</string>
     <string name="searching_devices">חיפוש התקנים</string>
-    <string name="use_custom_ip">להשתמש בכתובת IP מותאמת אישית</string>
     <string name="bookmark_lost">הסימניה לא נמצאה, נוצרת מחדש&#8230;</string>
 
     <string name="smb_instructions">

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -319,7 +319,6 @@
     <string name="translate_summary">Fordítsa le az Amaze fájlkezelőjét a saját nyelvére</string>
     <string name="paypal_copy_message">A Paypal id a vágólapra lett másolva</string>
     <string name="searching_devices">Eszközök keresése</string>
-    <string name="use_custom_ip">Egyéni IP használata</string>
     <string name="bookmark_lost">Nem található könyvjelző, létrehozás újra&#8230;</string>
 
     <string name="share_limit">Nem oszthat meg 100-nál több fájlt</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -324,7 +324,6 @@
     <string name="translate_summary">Terjemahkan Amaze ke dalam bahasa Anda</string>
     <string name="paypal_copy_message">Id Paypal disalin ke papan klip</string>
     <string name="searching_devices">Mencari perangkat</string>
-    <string name="use_custom_ip">Gunakan IP khusus</string>
     <string name="bookmark_lost">Markah tidak ditemukan, membuat ulang&#8230;</string>
 
     <string name="share_limit">Tidak bisa membagikan lebih dari 100 berkas</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -313,7 +313,6 @@
     <string name="translate_summary">Þýða Amaze á tungumálið þitt</string>
     <string name="paypal_copy_message">Paypal auðkenni afritað á klippispjald</string>
     <string name="searching_devices">Leita að tækjum...</string>
-    <string name="use_custom_ip">Nota sérsniðið IP-vistfang</string>
     <string name="bookmark_lost">Bókamerki fannst ekki, útbý aftur&#8230;</string>
 
     <string name="share_limit">Get ekki deilt fleiri en 100 skrám</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -328,7 +328,6 @@ altrimenti verrà controllata solo l\'occorrenza.</string>
     <string name="translate_summary">Traduci Amaze nella tua lingua</string>
     <string name="paypal_copy_message">ID PayPal copiato negli Appunti</string>
     <string name="searching_devices">Ricerca dispositivi in corso</string>
-    <string name="use_custom_ip">Utilizza IP personalizzato</string>
     <string name="bookmark_lost">Segnalibro non trovato, lo sto creando nuovamente&#8230;</string>
 
     <string name="share_limit">Impossibile condividere più di 100 file</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -240,6 +240,7 @@
     <string name="needs_access_summary">ルートディレクトリーを選択してください \\t</string>
     <string name="needs_access_summary1">\\t操作するために書き込みアクセスを付与します </string>
     <string name="smb_connection">SMB 接続</string>
+    <string name="smb_server">SMB サーバーホスト名</string>
     <string name="server_address">サーバー IP アドレス</string>
     <string name="username">ユーザー名</string>
     <string name="password">パスワード</string>
@@ -316,7 +317,7 @@
     <string name="translate_summary">Amaze をお使いの言語に翻訳します</string>
     <string name="paypal_copy_message">PayPal ID をクリップボードにコピーしました</string>
     <string name="searching_devices">デバイスの検索中</string>
-    <string name="use_custom_ip">カスタム IP を使用する</string>
+    <string name="smb_manual_enter_host">ホスト名を手動で入力</string>
     <string name="bookmark_lost">ブックマークが見つかりません。再作成中&#8230;</string>
 
     <string name="share_limit">100 ファイル以上を共有することはできません</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -292,7 +292,6 @@
     <string name="translate_title">번역</string>
     <string name="translate_summary">Amaze 의 현지화(번역)를 도와주세요</string>
     <string name="searching_devices">기기를 찾는 중</string>
-    <string name="use_custom_ip">사용자 정의 IP 사용</string>
     <string name="bookmark_lost">북마크를 찾을 수 없어 재생성 합니다</string>
 
     <string name="share_limit">100 개 이상의 파일은 공유할 수 없습니다</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -319,7 +319,6 @@
     <string name="translate_summary">Translate Amaze in your language</string>
     <string name="paypal_copy_message">PayPal ID copied to clipboard</string>
     <string name="searching_devices">Searching for devices</string>
-    <string name="use_custom_ip">Use custom IP</string>
     <string name="bookmark_lost">Bookmark not found, recreating&#8230;</string>
 
     <string name="share_limit">Can\'t share more than 100 files</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -303,7 +303,6 @@ Anders wordt er naar een voorval gezocht.</string>
     <string name="easter_egg_title">Studiomodus</string>
     <string name="paypal_copy_message">PayPal Id gekopieerd naar klembord</string>
     <string name="searching_devices">Zoeken naar apparaten</string>
-    <string name="use_custom_ip">Gebruik aangepast IP</string>
     <string name="bookmark_lost">Bladwijzer niet gevonden, opnieuw aan het maken&#8230;</string>
 
     <string name="share_limit">Kan niet meer dan 100 bestanden delen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -318,7 +318,6 @@
     <string name="translate_summary">Umożliwia przetłumaczenie aplikacji na dany język</string>
     <string name="paypal_copy_message">Skopiowano do schowka identyfikator Paypal</string>
     <string name="searching_devices">Szukanie urządzeń</string>
-    <string name="use_custom_ip">Własne IP</string>
     <string name="bookmark_lost">Nie odnaleziono zakładki, ponowne tworzenie&#8230;</string>
 
     <string name="share_limit">Nie możesz udostępnić więcej niż 100 plików</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -318,7 +318,6 @@
     <string name="translate_summary">Traduza o Amaze para seu idioma</string>
     <string name="paypal_copy_message">ID do Paypal copiado para a área de transferência</string>
     <string name="searching_devices">Procurando dispositivos</string>
-    <string name="use_custom_ip">Usar IP personalizado</string>
     <string name="bookmark_lost">Favorito não encontrado, recriando&#8230;</string>
 
     <string name="share_limit">Não é possível compartilhar mais que 100 arquivos</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -319,7 +319,6 @@ Se inativa, será procurada qualquer correspondência.</string>
     <string name="translate_summary">Traduza o Amaze para o seu idioma</string>
     <string name="paypal_copy_message">ID Paypal copiada para a área de transferência</string>
     <string name="searching_devices">A pesquisar por dispositivos</string>
-    <string name="use_custom_ip">Utilizar IP personalizado</string>
     <string name="bookmark_lost">Marcador não encontrado, a recriar&#8230;</string>
 
     <string name="share_limit">Não é possível partilhar mais de 100 ficheiros.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -320,7 +320,6 @@
     <string name="translate_summary">Перевести Amaze на ваш язык</string>
     <string name="paypal_copy_message">Paypal id скопирован в буфер обмена</string>
     <string name="searching_devices">Поиск устройств</string>
-    <string name="use_custom_ip">Использовать другой IP</string>
     <string name="bookmark_lost">Закладка не найдена, пересоздание&#8230;</string>
 
     <string name="share_limit">Нельзя отправить больше 100 файлов</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -305,7 +305,6 @@
     <string name="translate_summary">Preložiť Amaze do vašho jazyka</string>
     <string name="paypal_copy_message">Paypal id bol skopírovaný do schránky</string>
     <string name="searching_devices">Vyhľadávajú sa zariadenia...</string>
-    <string name="use_custom_ip">Použiť inú IP</string>
     <string name="bookmark_lost">Záložka sa nenašla, obnovovanie&#8230;</string>
 
     <string name="share_limit">Nemôžete zdieľať viac ako 100 súborov</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -275,7 +275,6 @@
     <string name="translate_summary">Prevedite Amaze v vaš jezik</string>
     <string name="paypal_copy_message">PayPal id kopiran v odložišče</string>
     <string name="searching_devices">Iskanje naprav</string>
-    <string name="use_custom_ip">Uporaba IP po meri</string>
     <string name="share_limit">Ne moremo deliti več kot 100 datotek</string>
     <string name="otg_access">Izberite koren OTG naprave</string>
     <string name="information">Podatki</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -302,7 +302,6 @@
     <string name="easter_egg_title">Студијски режим</string>
     <string name="paypal_copy_message">Пејпел ИД копиран на клипборд</string>
     <string name="searching_devices">Тражим уређаје</string>
-    <string name="use_custom_ip">Користите прилагођену ИП</string>
     <string name="bookmark_lost">Обележивач није нађен, поново правим&#8230;</string>
 
     <string name="share_limit">Не могу да делим више од 100 фајлова</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -301,7 +301,6 @@ kommer annars att söka efter förekomster.</string>
   <string name="easter_egg_title">Studioläge</string>
     <string name="paypal_copy_message">Paypal-ID kopierat till utklipp</string>
     <string name="searching_devices">Söker efter enheter</string>
-    <string name="use_custom_ip">Använd anpassat IP</string>
     <string name="bookmark_lost">Bokmärke hittades ej, återskapar&#8230;</string>
 
     <string name="share_limit">Kan inte dela mer än 100 filer</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -311,7 +311,6 @@ kommer annars att söka efter förekomster.</string>
     <string name="translate_summary">Översätt Amaze till ditt språk</string>
     <string name="paypal_copy_message">PayPal-UD kopierat till urklipp</string>
     <string name="searching_devices">Söker efter enheter</string>
-    <string name="use_custom_ip">Använd egen IP</string>
     <string name="bookmark_lost">Bokmärke hittades inte, återskapar&#8230;</string>
 
     <string name="share_limit">Kan inte dela fler än 100 filer</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -304,7 +304,6 @@
     <string name="easter_egg_title">ஸ்டூடியோ முறை</string>
     <string name="paypal_copy_message">பேபால் ஐடி பிடிப்புபலகைக்கு நகலெடுக்கப்பட்டது</string>
     <string name="searching_devices">சாதனத்தை தேடுகிறது</string>
-    <string name="use_custom_ip">பயனர் ஐபியை பயன்படுத்து</string>
     <string name="bookmark_lost">புத்தகக்குறி காணப்படவில்லை, மறுஉருவாக்குகிறது&#8230;</string>
 
     <string name="share_limit">100 கோப்புகளுக்கு மேல் பகிரமுடியாது</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -318,7 +318,6 @@
     <string name="translate_summary">Amaze uygulamasını kendi dilinize çevirin</string>
     <string name="paypal_copy_message">Paypal ID panoya kopyalandı</string>
     <string name="searching_devices">Cihazlar aranıyor</string>
-    <string name="use_custom_ip">Özel IP kullan</string>
     <string name="bookmark_lost">Yer imi bulunamadı, oluşturuluyor&#8230;</string>
 
     <string name="share_limit">100 dosyadan fazlası paylaşılamaz</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -241,6 +241,7 @@
     <string name="needs_access_summary">Будь ласка виберіть кореневий каталог \t</string>
     <string name="needs_access_summary1">\tнадати доступ на запис для роботи </string>
     <string name="smb_connection">Samba з\'єднання</string>
+    <string name="smb_server">Ім\'я хоста сервера SMB</string>
     <string name="server_address">IP-адреса сервера</string>
     <string name="username">Користувач</string>
     <string name="password">Пароль</string>
@@ -316,7 +317,7 @@
     <string name="translate_summary">Перекласти Amaze вашою мовою</string>
     <string name="paypal_copy_message">PayPal id скопійовано до буфера обміну</string>
     <string name="searching_devices">Пошук пристроїв</string>
-    <string name="use_custom_ip">Використовувати користувацьку IP</string>
+    <string name="smb_manual_enter_host">Введіть ім\'я хоста вручну</string>
     <string name="bookmark_lost">Закладки не знайдено, перестворення&#8230;</string>
 
     <string name="share_limit">Неможливо обмінюватися понад 100 файлами</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -316,7 +316,6 @@
     <string name="translate_summary">Dịch Amaze sang ngôn ngữ của bạn</string>
     <string name="paypal_copy_message">Đã chép ID Paypal vào clipboard</string>
     <string name="searching_devices">Đang tìm kiếm thiết bị</string>
-    <string name="use_custom_ip">Dùng IP tuỳ chỉnh</string>
     <string name="bookmark_lost">Không phát hiện dấu trang, đang tạo lại&#8230;</string>
 
     <string name="share_limit">Không thể chia sẻ hơn 100 tập tin</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -243,7 +243,7 @@
     <string name="needs_access_summary">请选择根目录下的 \t</string>
     <string name="needs_access_summary1">授予当前操作写入权限</string>
     <string name="smb_connection">服务器通讯包协议连接</string>
-    <string name="smb_server">服务器互联网协议地址</string>
+    <string name="smb_server">SMB服务器地址</string>
     <string name="server_address">服务器互联网协议地址</string>
     <string name="username">用户名</string>
     <string name="password">密码</string>
@@ -319,7 +319,6 @@
     <string name="translate_summary">将Amaze程序翻译为您的语言</string>
     <string name="paypal_copy_message">Paypal ID 已复制至剪切板</string>
     <string name="searching_devices">正在搜索设备</string>
-    <string name="use_custom_ip">使用自定义 IP</string>
     <string name="bookmark_lost">无法找到书签，正在重新创建&#8230;</string>
 
     <string name="share_limit">最多只能分享 100 个文件</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -242,7 +242,7 @@
     <string name="needs_access_summary">請選擇根目錄下的 \t</string>
     <string name="needs_access_summary1">\t 以授予寫入的權限</string>
     <string name="smb_connection">SMB 連線</string>
-    <string name="smb_server">伺服器 IP 位址</string>
+    <string name="smb_server">SMB伺服器主機名稱</string>
     <string name="server_address">伺服器 IP 位址</string>
     <string name="username">使用者名稱</string>
     <string name="password">密碼</string>
@@ -318,7 +318,7 @@
     <string name="translate_summary">用您的語言翻譯 Amaze</string>
     <string name="paypal_copy_message">Paypal ID 已複製到剪貼簿</string>
     <string name="searching_devices">正在搜尋裝置</string>
-    <string name="use_custom_ip">使用自訂的 IP</string>
+    <string name="smb_manual_enter_host">手動輸入主機名稱</string>
     <string name="bookmark_lost">找不到，重新建立書籤......</string>
 
     <string name="share_limit">無法分享超過 100 個檔案</string>

--- a/app/src/main/res/values-zh-rHN/strings.xml
+++ b/app/src/main/res/values-zh-rHN/strings.xml
@@ -242,7 +242,7 @@
     <string name="needs_access_summary">请选择根目录下的 \t</string>
     <string name="needs_access_summary1">\t 以授予寫入的權限</string>
     <string name="smb_connection">SMB 連線</string>
-    <string name="smb_server">伺服器 IP 位址</string>
+    <string name="smb_server">SMB伺服器主機名稱</string>
     <string name="server_address">伺服器 IP 位址</string>
     <string name="username">用户名</string>
     <string name="password">密碼</string>
@@ -318,7 +318,6 @@
     <string name="translate_summary">前往 Amaze 本地化系统进行语言翻译</string>
     <string name="paypal_copy_message">Paypal ID 已複製到剪貼簿</string>
     <string name="searching_devices">正在搜尋裝置</string>
-    <string name="use_custom_ip">使用自定义 IP</string>
     <string name="bookmark_lost">无法找到书签，正在重新创建&#8230;</string>
 
     <string name="share_limit">最多只能分享 100 个文件</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -242,7 +242,7 @@
     <string name="needs_access_summary">請選擇根目錄下的 \t</string>
     <string name="needs_access_summary1">\t 以授予寫入的權限</string>
     <string name="smb_connection">SMB 連線</string>
-    <string name="smb_server">伺服器 IP 位址</string>
+    <string name="smb_server">SMB伺服器主機名稱</string>
     <string name="server_address">伺服器 IP 位址</string>
     <string name="username">使用者名稱</string>
     <string name="password">密碼</string>
@@ -318,7 +318,7 @@
     <string name="translate_summary">用您的語言翻譯 Amaze</string>
     <string name="paypal_copy_message">Paypal ID 已複製到剪貼簿</string>
     <string name="searching_devices">正在搜尋裝置</string>
-    <string name="use_custom_ip">使用自訂的 IP</string>
+    <string name="smb_manual_enter_host">手動輸入主機名稱</string>
     <string name="bookmark_lost">找不到，重新建立書籤......</string>
 
     <string name="share_limit">無法分享超過 100 個檔案</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,7 +250,7 @@
     <string name="needs_access_summary">Please choose the root directory of \t</string>
     <string name="needs_access_summary1">\tto grant write access to operate </string>
     <string name="smb_connection">SMB Connection</string>
-    <string name="smb_server">Server IP Address</string>
+    <string name="smb_server">SMB Server Hostname</string>
     <string name="server_address">Server IP Address</string>
     <string name="username">Username</string>
     <string name="password">Password</string>
@@ -327,7 +327,7 @@
     <string name="translate_summary">Translate Amaze in your language</string>
     <string name="paypal_copy_message">PayPal ID copied to clipboard</string>
     <string name="searching_devices">Searching for devices</string>
-    <string name="use_custom_ip">Use custom IP</string>
+    <string name="smb_manual_enter_host">Enter Hostname Manually</string>
     <string name="bookmark_lost">Bookmark not found, recreating&#8230;</string>
 
     <string name="smb_instructions"><![CDATA[


### PR DESCRIPTION
## Description

SMB connections can use hostnames directly. Changed wordings to reduce confusion.

Also rephrased "Enter Hostname Manually" instead of "Use Custom IP".

#### Issue tracker   

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
- Device: Pixel 4 Emulator
- OS: Android 10

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->