### PR TITLE
Build improvements

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up NDK
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
-          ndk-version: r29
+          ndk-version: r27d
           link-to-sdk: true
           local-cache: true
       - name: Install Rust

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up NDK
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
-          ndk-version: r28c
+          ndk-version: r29
           link-to-sdk: true
           local-cache: true
       - name: Install Rust

--- a/.github/workflows/android-debug-artifact-ondemand.yml
+++ b/.github/workflows/android-debug-artifact-ondemand.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up NDK
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
-          ndk-version: r28c
+          ndk-version: r29
           link-to-sdk: true
           local-cache: true
       - name: Install Rust

--- a/.github/workflows/android-debug-artifact-ondemand.yml
+++ b/.github/workflows/android-debug-artifact-ondemand.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up NDK
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
-          ndk-version: r29
+          ndk-version: r27d
           link-to-sdk: true
           local-cache: true
       - name: Install Rust

--- a/.github/workflows/android-debug-artifact-release.yml
+++ b/.github/workflows/android-debug-artifact-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up NDK
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
-          ndk-version: r28c
+          ndk-version: r29
           link-to-sdk: true
           local-cache: true
       - name: Install Rust

--- a/.github/workflows/android-debug-artifact-release.yml
+++ b/.github/workflows/android-debug-artifact-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up NDK
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
-          ndk-version: r29
+          ndk-version: r27d
           link-to-sdk: true
           local-cache: true
       - name: Install Rust

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -26,7 +26,7 @@ jobs:
         id: setup-ndk
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
-          ndk-version: r29
+          ndk-version: r27d
           link-to-sdk: true
           local-cache: true
       - name: Setup Gradle

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -26,7 +26,7 @@ jobs:
         id: setup-ndk
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
-          ndk-version: r28c
+          ndk-version: r29
           link-to-sdk: true
           local-cache: true
       - name: Setup Gradle

--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up NDK
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
-          ndk-version: r28c
+          ndk-version: r29
           link-to-sdk: true
           local-cache: true
       - name: Setup Gradle

--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up NDK
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
-          ndk-version: r29
+          ndk-version: r27d
           link-to-sdk: true
           local-cache: true
       - name: Setup Gradle

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'com.google.devtools.ksp'
 
 android {
     namespace "com.amaze.filemanager"
-    compileSdk libs.versions.compileSdk.get().toInteger()
+    compileSdk tools.versions.compileSdk.get().toInteger()
     packagingOptions {
         resources {
             excludes += ['proguard-project.txt', 'project.properties', 'META-INF/LICENSE.txt', 'META-INF/LICENSE', 'META-INF/NOTICE.txt', 'META-INF/NOTICE', 'META-INF/DEPENDENCIES.txt', 'META-INF/DEPENDENCIES', 'META-INF/versions/9/OSGI-INF/MANIFEST.MF']
@@ -99,7 +99,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = tools.versions.jvmTarget.get()
     }
 
     testOptions {
@@ -336,5 +336,4 @@ repositories {
     google()
     mavenCentral()
     maven { url "https://jitpack.io" }
-    maven { url "https://jcenter.bintray.com" }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ allprojects {
         google()
         mavenCentral()
         maven { url "https://jitpack.io" }
-        maven { url "https://jcenter.bintray.com" }
         maven { url "https://repository.liferay.com/nexus/content/repositories/public/"}
     }
     tasks.withType(Test).tap {

--- a/commons_compress_7z/build.gradle
+++ b/commons_compress_7z/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace "com.amaze.filemanager.filesystem.compressed.sevenz"
-    compileSdk libs.versions.compileSdk.get().toInteger()
+    compileSdk tools.versions.compileSdk.get().toInteger()
 
     defaultConfig {
         minSdkVersion libs.versions.minSdk.get().toInteger()

--- a/file_operations/build.gradle
+++ b/file_operations/build.gradle
@@ -2,15 +2,16 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.google.devtools.ksp'
 apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
+apply from: "../gradle/setupRustAndroidLocal.gradle"
 
 android {
     namespace "com.amaze.filemanager.fileoperations"
-    compileSdk libs.versions.compileSdk.get().toInteger()
-    ndkVersion libs.versions.ndk.get()
+    compileSdk tools.versions.compileSdk.get().toInteger()
+    ndkVersion tools.versions.ndk.get()
 
     defaultConfig {
         minSdkVersion libs.versions.minSdk.get().toInteger()
-        ndkVersion libs.versions.ndk.get()
+        ndkVersion tools.versions.ndk.get()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -43,7 +44,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = tools.versions.jvmTarget.get()
     }
 }
 
@@ -61,7 +62,7 @@ cargo {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(tools.versions.jvmTarget.get().toInteger())
 }
 
 // Ensure Rust libraries are built before Android tasks
@@ -135,4 +136,10 @@ dependencies {
 
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation libs.androidX.appcompat
+}
+
+tasks.matching {
+    it.name.startsWith('cargoBuild')
+}.configureEach {
+    it.dependsOn 'setupRustAndroidLocal'
 }

--- a/file_operations/setup_rust_android.sh
+++ b/file_operations/setup_rust_android.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Setup script for Rust Android development
 # This script:

--- a/file_operations/setup_rust_android.sh
+++ b/file_operations/setup_rust_android.sh
@@ -35,11 +35,25 @@ find_android_sdk() {
     fi
 }
 
-# Function to find the latest NDK version
+# Function to find the NDK version (from tools.versions.toml or latest)
 find_ndk_version() {
     local sdk_path="$1"
     local ndk_dir="$sdk_path/ndk"
-    
+    local version_catalog="../gradle/tools.versions.toml"
+
+    # First, try to read NDK version from tools.versions.toml
+    if [ -f "$version_catalog" ]; then
+        local ndk_version=$(grep "^ndk" "$version_catalog" | cut -d '"' -f 2)
+        if [ -n "$ndk_version" ] && [ -d "$ndk_dir/$ndk_version" ]; then
+            echo "$ndk_version"
+            return
+        elif [ -n "$ndk_version" ]; then
+            echo "⚠️  Warning: NDK version $ndk_version specified in tools.versions.toml not found in $ndk_dir" >&2
+            echo "   Falling back to latest available version..." >&2
+        fi
+    fi
+
+    # Fall back to finding the latest version
     if [ -d "$ndk_dir" ]; then
         # Find the latest version (highest version number)
         ls -1 "$ndk_dir" | sort -V | tail -n 1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,7 @@
 [versions]
-compileSdk = "34"
 minSdk = "21"
 targetSdk = "35"
 kotlin = "1.9.25"
-ndk = "28.2.13676358" #r28c
 
 jacocoAndroid = "0.2.1"
 gradle = "8.5.2"

--- a/gradle/setupRustAndroidLocal.gradle
+++ b/gradle/setupRustAndroidLocal.gradle
@@ -1,0 +1,31 @@
+tasks.register("setupRustAndroidLocal") {
+
+    onlyIf { System.getenv("GITHUB_ACTIONS") == null }
+
+    doFirst {
+        println("Setting up Rust for Android build...")
+    }
+
+    // Detect existence of rustup.
+    def rustupExists = exec {
+        commandLine("which", "rustup")
+        ignoreExitValue true
+    }.exitValue == 0
+
+    if (!rustupExists) {
+        println("rustup not found. Installing rustup...")
+        exec {
+            commandLine("sh", "-c",
+                "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -v --default-toolchain none --no-modify-path"
+            )
+        }
+    }
+
+    doLast {
+        exec {
+            workingDir file(rootProject.project("file_operations").projectDir)
+            commandLine("env", "bash", "setup_rust_android.sh")
+        }
+        println("Rust targets for Android have been set up successfully.")
+    }
+}

--- a/gradle/setupRustAndroidLocal.gradle
+++ b/gradle/setupRustAndroidLocal.gradle
@@ -7,18 +7,33 @@ tasks.register("setupRustAndroidLocal") {
     }
 
     // Detect existence of rustup.
-    def rustupExists = exec {
-        commandLine("which", "rustup")
-        ignoreExitValue true
-    }.exitValue == 0
+    def rustupExists = {
+
+        // First check common installation path
+        def isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
+        def home = System.getProperty("user.home")
+        def rustupPath = isWindows
+            ? new File(home, ".cargo/bin/rustup.exe")
+            : new File(home, ".cargo/bin/rustup")
+
+        if (rustupPath.exists() && rustupPath.canExecute()) {
+            return true
+        }
+
+        // If not, check on user $PATH/%PATH%
+        try {
+            def process = new ProcessBuilder("rustup")
+                .redirectErrorStream(true)
+                .start()
+            process.waitFor()
+            return process.exitValue() == 0
+        } catch (IOException ignored) {
+            return false
+        }
+    }()
 
     if (!rustupExists) {
-        println("rustup not found. Installing rustup...")
-        exec {
-            commandLine("sh", "-c",
-                "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -v --default-toolchain none --no-modify-path"
-            )
-        }
+        throw new GradleException("rustup is not installed or not found in PATH. Please install rustup from https://rustup.rs/ and ensure it is accessible.")
     }
 
     doLast {

--- a/gradle/tools.versions.toml
+++ b/gradle/tools.versions.toml
@@ -1,0 +1,4 @@
+[versions]
+compileSdk = "34"
+jvmTarget = "17"
+ndk = "29.0.14206865" #r29

--- a/gradle/tools.versions.toml
+++ b/gradle/tools.versions.toml
@@ -1,4 +1,4 @@
 [versions]
 compileSdk = "34"
 jvmTarget = "17"
-ndk = "29.0.14206865" #r29
+ndk = "27.3.13750724" #r27d LTS

--- a/portscanner/build.gradle
+++ b/portscanner/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-parcelize'
 
 android {
     namespace 'com.stealthcopter.networktools'
-    compileSdk libs.versions.compileSdk.get().toInteger()
+    compileSdk tools.versions.compileSdk.get().toInteger()
 
     defaultConfig {
         minSdk libs.versions.minSdk.get().toInteger()
@@ -28,7 +28,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(tools.versions.jvmTarget.get().toInteger())
 }
 
 dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,11 @@
 include ':file_operations'
 include ':portscanner'
 include ':app', ':commons_compress_7z'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("tools") {
+            from(files("gradle/tools.versions.toml"))
+        }
+    }
+}


### PR DESCRIPTION
## Description

Changes per mentioned in #4551, hopefully can help create reproducible builds outside Github Actions.

- Remove JCenter repo since it's no longer available
- Created new version catalog for tool versions
- Added setupRustAndroidLocal task for easier setup environment for compiling Rust module in file_operations
- Update NDK to current ~~stable version 29~~ LTS version 27d

#### Issue tracker   
Addresses #4551 

#### Build tasks success  
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`