### PR TITLE
Fix crash when opening Recent Files without storage permission

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -551,29 +551,34 @@ public class LoadFilesListTask
     c.set(Calendar.DAY_OF_YEAR, c.get(Calendar.DAY_OF_YEAR) - 2);
     Date d = c.getTime();
     Cursor cursor;
-    if (SDK_INT >= Q) {
-      Bundle queryArgs = new Bundle();
-      queryArgs.putInt(ContentResolver.QUERY_ARG_LIMIT, 20);
-      queryArgs.putStringArray(
-          ContentResolver.QUERY_ARG_SORT_COLUMNS,
-          new String[] {MediaStore.Files.FileColumns.DATE_MODIFIED});
-      queryArgs.putInt(
-          ContentResolver.QUERY_ARG_SORT_DIRECTION,
-          ContentResolver.QUERY_SORT_DIRECTION_DESCENDING);
-      cursor =
-          context
-              .getContentResolver()
-              .query(MediaStore.Files.getContentUri("external"), projection, queryArgs, null);
-    } else {
-      cursor =
-          context
-              .getContentResolver()
-              .query(
-                  MediaStore.Files.getContentUri("external"),
-                  projection,
-                  null,
-                  null,
-                  MediaStore.Files.FileColumns.DATE_MODIFIED + " DESC LIMIT 20");
+    try {
+      if (SDK_INT >= Q) {
+        Bundle queryArgs = new Bundle();
+        queryArgs.putInt(ContentResolver.QUERY_ARG_LIMIT, 20);
+        queryArgs.putStringArray(
+            ContentResolver.QUERY_ARG_SORT_COLUMNS,
+            new String[] {MediaStore.Files.FileColumns.DATE_MODIFIED});
+        queryArgs.putInt(
+            ContentResolver.QUERY_ARG_SORT_DIRECTION,
+            ContentResolver.QUERY_SORT_DIRECTION_DESCENDING);
+        cursor =
+            context
+                .getContentResolver()
+                .query(MediaStore.Files.getContentUri("external"), projection, queryArgs, null);
+      } else {
+        cursor =
+            context
+                .getContentResolver()
+                .query(
+                    MediaStore.Files.getContentUri("external"),
+                    projection,
+                    null,
+                    null,
+                    MediaStore.Files.FileColumns.DATE_MODIFIED + " DESC LIMIT 20");
+      }
+    } catch (SecurityException e) {
+      // Storage permission denied; treat as no recent files instead of crashing.
+      return recentFiles;
     }
     if (cursor == null) return recentFiles;
     if (cursor.getCount() > 0 && cursor.moveToFirst()) {


### PR DESCRIPTION
## Description
Fix crash when opening **Recent Files** while storage permission is denied on `release/4.0`.

### Root cause
`LoadFilesListTask.listRecentFiles()` performs a `MediaStore` query that can throw `SecurityException` when `READ_EXTERNAL_STORAGE` is denied. The exception escapes `AsyncTask.doInBackground()` and crashes the app.

### Fix
Catch `SecurityException` around the `MediaStore` query and return the current `recentFiles` list (empty) when permission is denied.

### Behavior
- **Permission denied** → no crash; Recent Files shows empty list
- **Permission granted** → unchanged behavior

### Issue tracker
Addresses #3396

### Verification (manual)
- Device: Android Emulator (Pixel 2)
- OS: Android 8.1 (x86)
- Install: fresh
- Package tested: `com.amaze.filemanager.debug`
- Version: 3.11.2 (`versionCode 124`), build `v3.11.2-76-gd99897689`

Steps:
1. Launch app
2. Deny storage permission
3. Open **Recent Files**

Results:
- Before: crash with `SecurityException`
- After: no crash with permission denied
- Regression: works normally with permission granted

### Build checks
- [x] `./gradlew assembleDebug`
- [x] `./gradlew spotlessCheck`

Artifacts (logcat + screen recordings) captured locally; not included in the repo.