### PR TITLE
Fix navigation bar and notification bar invisible in newer Androids

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/ThemedActivity.java
@@ -21,7 +21,11 @@
 package com.amaze.filemanager.ui.activities.superclasses;
 
 import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.KITKAT_WATCH;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.M;
+import static android.os.Build.VERSION_CODES.O;
 import static com.amaze.filemanager.ui.fragments.preferencefragments.PreferencesConstants.PREFERENCE_COLORED_NAVIGATION;
 
 import com.amaze.filemanager.R;
@@ -44,7 +48,6 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.drawable.BitmapDrawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.view.View;
@@ -58,6 +61,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.preference.PreferenceManager;
 
 /** Created by arpitkh996 on 03-03-2016. */
@@ -87,6 +95,38 @@ public class ThemedActivity extends PreferenceActivity {
       };
 
   @Override
+  public void setContentView(int layoutResID) {
+    super.setContentView(layoutResID);
+    setupEdgeToEdgeInsets();
+  }
+
+  @Override
+  public void setContentView(View view) {
+    super.setContentView(view);
+    setupEdgeToEdgeInsets();
+  }
+
+  /**
+   * Apply system bar insets as padding on the content view to handle Android 15+ edge-to-edge
+   * enforcement. This ensures content is laid out below the status bar and above the navigation
+   * bar.
+   */
+  private void setupEdgeToEdgeInsets() {
+    if (SDK_INT >= 35) {
+      View contentView = findViewById(android.R.id.content);
+      if (contentView != null) {
+        ViewCompat.setOnApplyWindowInsetsListener(
+            contentView,
+            (v, windowInsets) -> {
+              Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+              v.setPadding(insets.left, insets.top, insets.right, insets.bottom);
+              return WindowInsetsCompat.CONSUMED;
+            });
+      }
+    }
+  }
+
+  @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
@@ -108,7 +148,7 @@ public class ThemedActivity extends PreferenceActivity {
       getColorPreference().saveColorPreferences(getPrefs(), ColorPreferenceHelper.randomize(this));
     }
 
-    if (SDK_INT >= 21) {
+    if (SDK_INT >= LOLLIPOP) {
       ActivityManager.TaskDescription taskDescription =
           new ActivityManager.TaskDescription(
               getString(R.string.appbar_name),
@@ -132,8 +172,13 @@ public class ThemedActivity extends PreferenceActivity {
     }
 
     Window window = getWindow();
-    if (SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      if (findViewById(R.id.tab_frame) != null || findViewById(R.id.drawer_layout) == null) {
+    if (SDK_INT >= LOLLIPOP) {
+      boolean useSolidStatusBar =
+          findViewById(R.id.tab_frame) != null
+              || findViewById(R.id.drawer_layout) == null
+              || getAppTheme().equals(AppTheme.LIGHT);
+
+      if (useSolidStatusBar) {
         window.setStatusBarColor(PreferenceUtils.getStatusColor(getPrimary()));
         window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
       } else {
@@ -150,8 +195,18 @@ public class ThemedActivity extends PreferenceActivity {
           window.setNavigationBarColor(Utils.getColor(this, R.color.holo_dark_background));
         }
       }
-    } else if (SDK_INT == Build.VERSION_CODES.KITKAT_WATCH
-        || SDK_INT == Build.VERSION_CODES.KITKAT) {
+
+      // Set light/dark icon appearance for system bars based on theme
+      if (SDK_INT >= M) {
+        WindowInsetsControllerCompat insetsController =
+            WindowCompat.getInsetsController(window, window.getDecorView());
+        boolean isLightTheme = getAppTheme().equals(AppTheme.LIGHT);
+        insetsController.setAppearanceLightStatusBars(isLightTheme);
+        if (SDK_INT >= O) {
+          insetsController.setAppearanceLightNavigationBars(isLightTheme);
+        }
+      }
+    } else if (SDK_INT == KITKAT_WATCH || SDK_INT == KITKAT) {
       setKitkatStatusBarMargin(parentView);
       setKitkatStatusBarTint();
     }
@@ -212,7 +267,7 @@ public class ThemedActivity extends PreferenceActivity {
 
   void setTheme() {
     AppTheme theme = getAppTheme();
-    if (Build.VERSION.SDK_INT >= 21) {
+    if (SDK_INT >= LOLLIPOP) {
 
       String stringRepresentation = String.format("#%06X", (0xFFFFFF & getAccent()));
 


### PR DESCRIPTION
## Description

Also fixes TextEditorActivity menu bar overlap with notification bar on newer Androids.

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
<!-- Fixes # -->
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  

Device: Fairphone 5
OS: LineageOS 23.2 (Android 16)

After change, the app will not taking the notification area and navigation bar.

<img width="308" height="675" alt="Screenshot_20260226-164530_Amaze Debug" src="https://github.com/user-attachments/assets/fbd4ca3b-7943-4905-bf73-f635d461689e" />
<img width="308" height="675" alt="Screenshot_20260226-164521_Amaze Debug" src="https://github.com/user-attachments/assets/710dff97-bea8-4251-8e37-851951284a0b" />
  

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`
