### PR TITLE
Fix browsing when storage permission is denied

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -413,7 +413,15 @@ public class MainActivity extends PermissionsActivity
       getPrefs().edit().putBoolean(PREFERENCE_BOOKMARKS_ADDED, true).commit();
     }
 
-    checkForExternalPermission();
+    String actionIntent = intent != null ? intent.getAction() : null;
+
+    if (Intent.ACTION_GET_CONTENT.equals(actionIntent)
+        || RingtoneManager.ACTION_RINGTONE_PICKER.equals(actionIntent)
+        || Intent.ACTION_VIEW.equals(actionIntent)
+        || Intent.ACTION_SEND.equals(actionIntent)
+        || Intent.ACTION_SEND_MULTIPLE.equals(actionIntent)) {
+      checkForExternalPermission();
+    }
 
     Completable.fromRunnable(
             () -> {
@@ -584,7 +592,7 @@ public class MainActivity extends PermissionsActivity
 
   /** Ensures storage permission is granted before allowing filesystem browsing. */
   private boolean ensureStoragePermission() {
-    if (SDK_INT < Build.VERSION_CODES.M) {
+    if (SDK_INT < M) {
       return true;
     }
 
@@ -1036,10 +1044,6 @@ public class MainActivity extends PermissionsActivity
    * @param hideFab Whether the FAB should be hidden in the new created {@link MainFragment} or not
    */
   public void goToMain(String path, boolean hideFab) {
-    // Prevent entering browsing UI if storage permission is missing.
-    if (!ensureStoragePermission()) {
-      return;
-    }
     FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
     // title.setText(R.string.app_name);
     TabFragment tabFragment = new TabFragment();

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/MainActivity.java
@@ -254,6 +254,8 @@ public class MainActivity extends PermissionsActivity
   public String oppathe, oppathe1;
   public ArrayList<String> oppatheList;
 
+  private boolean hadStoragePermission;
+
   // This holds the Uris to be written at initFabToSave()
   private List<Uri> urisToBeSaved;
 
@@ -578,6 +580,25 @@ public class MainActivity extends PermissionsActivity
         requestNotificationPermission(true);
       }
     }
+  }
+
+  /** Ensures storage permission is granted before allowing filesystem browsing. */
+  private boolean ensureStoragePermission() {
+    if (SDK_INT < Build.VERSION_CODES.M) {
+      return true;
+    }
+
+    if (checkStoragePermission()) {
+      return true;
+    }
+
+    if (SDK_INT >= Build.VERSION_CODES.R) {
+      requestAllFilesAccess(this);
+    } else {
+      requestStoragePermission(this, true);
+    }
+
+    return false;
   }
 
   /** Checks for the action to take when Amaze receives an intent from external source */
@@ -1015,6 +1036,10 @@ public class MainActivity extends PermissionsActivity
    * @param hideFab Whether the FAB should be hidden in the new created {@link MainFragment} or not
    */
   public void goToMain(String path, boolean hideFab) {
+    // Prevent entering browsing UI if storage permission is missing.
+    if (!ensureStoragePermission()) {
+      return;
+    }
     FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
     // title.setText(R.string.app_name);
     TabFragment tabFragment = new TabFragment();
@@ -1354,6 +1379,15 @@ public class MainActivity extends PermissionsActivity
       materialDialog.show();
       materialDialog = null;
     }
+
+    boolean hasPermissionNow = checkStoragePermission();
+
+    if (!hadStoragePermission && hasPermissionNow) {
+      goToMain(null);
+    }
+
+    hadStoragePermission = hasPermissionNow;
+    ensureStoragePermission();
 
     drawer.refreshDrawer();
     drawer.refactorDrawerLockMode();

--- a/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/PermissionsActivity.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/activities/superclasses/PermissionsActivity.java
@@ -51,6 +51,7 @@ public class PermissionsActivity extends ThemedActivity
     implements ActivityCompat.OnRequestPermissionsResultCallback {
 
   private static final String TAG = PermissionsActivity.class.getSimpleName();
+  private MaterialDialog allFilesAccessDialog;
 
   public static final int PERMISSION_LENGTH = 4;
   public static final int STORAGE_PERMISSION = 0,
@@ -240,27 +241,42 @@ public class PermissionsActivity extends ThemedActivity
    * @param onPermissionGranted permission granted callback
    */
   public void requestAllFilesAccess(@NonNull final OnPermissionGranted onPermissionGranted) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
-      final boolean hasHtml = true;
-      final MaterialDialog materialDialog =
-          GeneralDialogCreation.showBasicDialog(
-              this,
-              R.string.grant_all_files_permission,
-              R.string.grantper,
-              R.string.grant,
-              R.string.cancel,
-              hasHtml);
-      materialDialog.getActionButton(DialogAction.NEGATIVE).setOnClickListener(v -> finish());
-      materialDialog
-          .getActionButton(DialogAction.POSITIVE)
-          .setOnClickListener(
-              v -> {
-                requestAllFilesAccessPermission(onPermissionGranted);
-                materialDialog.dismiss();
-              });
-      materialDialog.setCancelable(false);
-      materialDialog.show();
+    if (SDK_INT < Build.VERSION_CODES.R) {
+      return;
     }
+
+    if (Environment.isExternalStorageManager()) {
+      return;
+    }
+
+    if (allFilesAccessDialog != null && allFilesAccessDialog.isShowing()) {
+      return;
+    }
+
+    final boolean hasHtml = true;
+    final MaterialDialog materialDialog =
+        GeneralDialogCreation.showBasicDialog(
+            this,
+            R.string.grant_all_files_permission,
+            R.string.grantper,
+            R.string.grant,
+            R.string.cancel,
+            hasHtml);
+
+    allFilesAccessDialog = materialDialog;
+
+    materialDialog.setOnDismissListener(dialog -> allFilesAccessDialog = null);
+    materialDialog.getActionButton(DialogAction.NEGATIVE).setOnClickListener(v -> finish());
+
+    materialDialog
+        .getActionButton(DialogAction.POSITIVE)
+        .setOnClickListener(
+            v -> {
+              requestAllFilesAccessPermission(onPermissionGranted);
+              materialDialog.dismiss();
+            });
+    materialDialog.setCancelable(false);
+    materialDialog.show();
   }
 
   @RequiresApi(api = Build.VERSION_CODES.R)


### PR DESCRIPTION
## Description

User is allowed to use Amaze without granting permissions.

Check storage permission on resume so backing out of the
grant flow does not allow filesystem browsing without permission.

Track the All Files Access dialog to avoid stale permission
dialog state when resuming.

#### Issue tracker
Fixes #4570

#### Automatic tests
- [ ] Added test cases

#### Manual tests
- [x] Done

Reproduced the original bug on upstream build and verified
correct behavior with patched build.

- Device: Pixel 9 Pro emulator
- OS: Android 16 / API 36

* Device: Samsung SM-S711U
* OS: Android 16 / API 36

Before/after reproduction videos:

Before (upstream behavior):
<video src="https://github.com/user-attachments/assets/e9f54c9e-84f4-4fde-a69a-102171cf7a41" height="500px"/>

After (patched behavior):
<video src="https://github.com/user-attachments/assets/e78bedfa-ed61-4659-8124-b3d75a3d1308" height="500px"/>


#### Build tasks success

Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`