### PR TITLE
Fix FAB remaining hidden after returning Home from drawer views

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -434,6 +434,7 @@ public class MainFragment extends Fragment
       };
 
   public void home() {
+    setHideFab(false);
     loadlist((mainFragmentViewModel.getHome()), false, OpenMode.FILE, false);
   }
 


### PR DESCRIPTION
## Description

Reset `hideFab` before loading the Home path from drawer category views.

`hideFab` remained `true` when navigating Home from drawer category views, causing `showFab()` to keep the FloatingActionButton hidden even after loading a normal filesystem directory.

This change resets the flag before calling `loadlist()` when returning to Home.

#### Issue tracker
Fixes #4581

#### Automatic tests
- [ ] Added test cases

#### Manual tests
- [x] Done

- Device: Pixel 9 Pro (emulator)
- OS: Android 16.0
- Rooted: No
- Version: 3.11.2

#### Build tasks success
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`