### PR TITLE
Fix stale refresh in drawer category views

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -1238,11 +1238,17 @@ public class MainFragment extends Fragment
 
   public void updateList(boolean forceReload) {
     computeScroll();
+
+    boolean shouldForceReload =
+        forceReload
+            || mainFragmentViewModel.getOpenMode() == OpenMode.CUSTOM
+            || mainFragmentViewModel.getOpenMode() == OpenMode.TRASH_BIN;
+
     loadlist(
         mainFragmentViewModel.getCurrentPath(),
         true,
         mainFragmentViewModel.getOpenMode(),
-        forceReload);
+        shouldForceReload);
   }
 
   @Override

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -788,7 +788,7 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
 
       MainFragment mainFragment = mainActivity.getCurrentMainFragment();
       if (mainFragment != null) {
-        mainFragment.loadlist(pendingPath.getPath(), false, OpenMode.UNKNOWN, false);
+        mainFragment.loadlist(pendingPath.getPath(), false, OpenMode.UNKNOWN, true);
         // Set if the FAB should be hidden when displaying the pendingPath
         mainFragment.setHideFab(pendingPath.getHideFabInMainFragment());
         resetPendingPath();


### PR DESCRIPTION
## Description

Fix stale list behavior in drawer/category views (Documents, Images, Videos, etc.).

Create, rename, and delete operations were not reflected in these views
until a manual refresh or app restart.

Force reload when navigating to drawer category views and when updating
`OpenMode.CUSTOM` or `OpenMode.TRASH_BIN`, so the visible list reflects
current filesystem state.

#### Issue tracker
Fixes #4580

#### Before

https://private-user-images.githubusercontent.com/261868434/560335309-81987b88-5ab2-4ea6-9cac-96aba76a71a7.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzM3NTYzNzYsIm5iZiI6MTc3Mzc1NjA3NiwicGF0aCI6Ii8yNjE4Njg0MzQvNTYwMzM1MzA5LTgxOTg3Yjg4LTVhYjItNGVhNi05Y2FjLTk2YWJhNzZhNzFhNy5tcDQ_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwMzE3JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDMxN1QxNDAxMTZaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1lNjMxNTJmNDhkMTY1ZGYwZGEzYjBmMmM4MTU0ZmVkZDU0ODFkZDJkNjFjZDcwYjE5MzVkNWQ2ZDM1NjYyMTFjJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.PUy7hcBpVunuV39WTr-REkpFB-6usOhPnQqwsie-hcY

#### After


https://github.com/user-attachments/assets/9a4ec812-ec28-421b-876b-f695c6c47e35


#### Automatic tests
- [ ] Added test cases

#### Manual tests
- [x] Done

#### Smartphone:
- Device: Pixel 9 Pro (emulator)  
- OS: Android 16 (API 36)  
- Rooted: No  
- Version: 3.11.2

#### Verified behavior in:
- Recent Files
- Images
- Videos
- Audio
- Documents
- APKs
- Trash Bin

#### Scenarios tested:
- Create file → appears in drawer view
- Rename file → updated name reflected
- Permanently delete file → removed from drawer view

#### Build tasks success
Successfully running following tasks locally:
- [x] `./gradlew assembleDebug`
- [x] `./gradlew spotlessCheck`