### PR TITLE
Fix drawer category views not refreshing after file operations

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/application/AppConfig.java
+++ b/app/src/main/java/com/amaze/filemanager/application/AppConfig.java
@@ -313,4 +313,8 @@ public class AppConfig extends GlideApplication {
     }
     return trashBinConfig;
   }
+
+  public static String getTrashBinBasePath() {
+    return TRASH_BIN_BASE_PATH;
+  }
 }

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/LoadFilesListTask.java
@@ -376,22 +376,37 @@ public class LoadFilesListTask
 
   private List<LayoutElementParcelable> listImages() {
     final String[] projection = {MediaStore.Images.Media.DATA};
-    return listMediaCommon(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, projection, null);
+    final String selection = MediaStore.Files.FileColumns.DATA + " NOT LIKE ?";
+    final String[] selectionArgs = new String[] {AppConfig.getTrashBinBasePath() + "%"};
+    return listMediaCommon(
+        MediaStore.Images.Media.EXTERNAL_CONTENT_URI, projection, selection, selectionArgs);
   }
 
   private List<LayoutElementParcelable> listVideos() {
     final String[] projection = {MediaStore.Video.Media.DATA};
-    return listMediaCommon(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, projection, null);
+    final String selection = MediaStore.Files.FileColumns.DATA + " NOT LIKE ?";
+    final String[] selectionArgs = new String[] {AppConfig.getTrashBinBasePath() + "%"};
+    return listMediaCommon(
+        MediaStore.Video.Media.EXTERNAL_CONTENT_URI, projection, selection, selectionArgs);
   }
 
   private List<LayoutElementParcelable> listaudio() {
-    String selection = MediaStore.Audio.Media.IS_MUSIC + " != 0";
+    String selection =
+        MediaStore.Audio.Media.IS_MUSIC
+            + " != 0 AND "
+            + MediaStore.Files.FileColumns.DATA
+            + " NOT LIKE ?";
     String[] projection = {MediaStore.Audio.Media.DATA};
-    return listMediaCommon(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, projection, selection);
+    String[] selectionArgs = new String[] {AppConfig.getTrashBinBasePath() + "%"};
+    return listMediaCommon(
+        MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, projection, selection, selectionArgs);
   }
 
   private @Nullable List<LayoutElementParcelable> listMediaCommon(
-      Uri contentUri, @NonNull String[] projection, @Nullable String selection) {
+      Uri contentUri,
+      @NonNull String[] projection,
+      @Nullable String selection,
+      @Nullable String[] selectionArgs) {
     final Context context = this.context.get();
 
     if (context == null) {
@@ -400,7 +415,7 @@ public class LoadFilesListTask
     }
 
     Cursor cursor =
-        context.getContentResolver().query(contentUri, projection, selection, null, null);
+        context.getContentResolver().query(contentUri, projection, selection, selectionArgs, null);
 
     ArrayList<LayoutElementParcelable> retval = new ArrayList<>();
     if (cursor == null) return retval;
@@ -428,16 +443,22 @@ public class LoadFilesListTask
 
     ArrayList<LayoutElementParcelable> docs = new ArrayList<>();
     final String[] projection = {MediaStore.Files.FileColumns.DATA};
+    final String selection = MediaStore.Files.FileColumns.DATA + " NOT LIKE ?";
+    final String[] selectionArgs = new String[] {AppConfig.getTrashBinBasePath() + "%"};
     Cursor cursor =
         context
             .getContentResolver()
-            .query(MediaStore.Files.getContentUri("external"), projection, null, null, null);
+            .query(
+                MediaStore.Files.getContentUri("external"),
+                projection,
+                selection,
+                selectionArgs,
+                null);
 
     if (cursor == null) return docs;
     else if (cursor.getCount() > 0 && cursor.moveToFirst()) {
       do {
         String path = cursor.getString(cursor.getColumnIndex(MediaStore.Files.FileColumns.DATA));
-
         if (path != null
             && (path.endsWith(".pdf")
                 || path.endsWith(".doc")
@@ -484,11 +505,17 @@ public class LoadFilesListTask
 
     ArrayList<LayoutElementParcelable> apks = new ArrayList<>();
     final String[] projection = {MediaStore.Files.FileColumns.DATA};
-
+    final String selection = MediaStore.Files.FileColumns.DATA + " NOT LIKE ?";
+    final String[] selectionArgs = new String[] {AppConfig.getTrashBinBasePath() + "%"};
     Cursor cursor =
         context
             .getContentResolver()
-            .query(MediaStore.Files.getContentUri("external"), projection, null, null, null);
+            .query(
+                MediaStore.Files.getContentUri("external"),
+                projection,
+                selection,
+                selectionArgs,
+                null);
     if (cursor == null) return apks;
     else if (cursor.getCount() > 0 && cursor.moveToFirst()) {
       do {
@@ -547,6 +574,8 @@ public class LoadFilesListTask
     final String[] projection = {
       MediaStore.Files.FileColumns.DATA, MediaStore.Files.FileColumns.DATE_MODIFIED
     };
+    final String selection = MediaStore.Files.FileColumns.DATA + " NOT LIKE ?";
+    final String[] selectionArgs = new String[] {AppConfig.getTrashBinBasePath() + "%"};
     Calendar c = Calendar.getInstance();
     c.set(Calendar.DAY_OF_YEAR, c.get(Calendar.DAY_OF_YEAR) - 2);
     Date d = c.getTime();
@@ -561,6 +590,8 @@ public class LoadFilesListTask
         queryArgs.putInt(
             ContentResolver.QUERY_ARG_SORT_DIRECTION,
             ContentResolver.QUERY_SORT_DIRECTION_DESCENDING);
+        queryArgs.putString(ContentResolver.QUERY_ARG_SQL_SELECTION, selection);
+        queryArgs.putStringArray(ContentResolver.QUERY_ARG_SQL_SELECTION_ARGS, selectionArgs);
         cursor =
             context
                 .getContentResolver()
@@ -572,8 +603,8 @@ public class LoadFilesListTask
                 .query(
                     MediaStore.Files.getContentUri("external"),
                     projection,
-                    null,
-                    null,
+                    selection,
+                    selectionArgs,
                     MediaStore.Files.FileColumns.DATE_MODIFIED + " DESC LIMIT 20");
       }
     } catch (SecurityException e) {

--- a/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/fragments/MainFragment.java
@@ -1242,7 +1242,7 @@ public class MainFragment extends Fragment
         mainFragmentViewModel.getCurrentPath(),
         true,
         mainFragmentViewModel.getOpenMode(),
-        forceReload);
+        forceReload || mainFragmentViewModel.getOpenMode() == OpenMode.CUSTOM);
   }
 
   @Override

--- a/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/views/drawer/Drawer.java
@@ -788,7 +788,8 @@ public class Drawer implements NavigationView.OnNavigationItemSelectedListener {
 
       MainFragment mainFragment = mainActivity.getCurrentMainFragment();
       if (mainFragment != null) {
-        mainFragment.loadlist(pendingPath.getPath(), false, OpenMode.UNKNOWN, false);
+        mainFragment.loadlist(
+            pendingPath.getPath(), false, OpenMode.UNKNOWN, hFile.getMode() == OpenMode.CUSTOM);
         // Set if the FAB should be hidden when displaying the pendingPath
         mainFragment.setHideFab(pendingPath.getHideFabInMainFragment());
         resetPendingPath();


### PR DESCRIPTION
## Description

Drawer category views did not consistently reflect filesystem changes
after file operations such as create and delete.

In some categories (Documents, APKs, Recent Files), queries could include
entries from Amaze's trash directory (.AmazeData), causing deleted files
to remain visible and allowing repeated deletes to create duplicate
Trash Bin entries.

This PR addresses the issue by:
- forcing reload for drawer category views to ensure fresh data after operations
- filtering Amaze trash paths from category queries

This ensures drawer views correctly reflect the current filesystem state
across all categories.

#### Issue tracker
Fixes #4558

#### Automatic tests
- [ ] Added test cases

#### Manual tests
- [x] Done

- Device: Pixel 9 Pro (emulator)
- OS: Android 16.0
- Rooted: No
- Version: 3.11.2

Verified in:
- Documents
- APKs
- Recent Files
- Images
- Videos
- Audio

Scenarios tested:
- Delete file → removed from drawer view
- Repeat delete → not possible (item is no longer visible after deletion)

### Before/after reproduction videos:

#### Before

https://github.com/user-attachments/assets/4d083fba-5e38-4df2-9763-057fb53fecad

#### After

https://github.com/user-attachments/assets/9343bcff-60e7-4ba5-8a25-73a66d879b06

#### Build tasks success
Successfully running the following tasks locally:
- [x] `./gradlew assembleDebug`
- [x] `./gradlew spotlessCheck`