### PR TITLE
ci: upgrade the action for node 24

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -15,14 +15,14 @@ jobs:
     name: Check spotless
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
       - name: Set up NDK
-        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
+        uses: nttld/setup-ndk@v1
         with:
           ndk-version: r28c
           link-to-sdk: true
@@ -32,7 +32,7 @@ jobs:
         with:
           toolchain: stable
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -61,7 +61,7 @@ jobs:
             exit 1
           fi
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
       - name: Check formatting using spotless
         run: ./gradlew spotlessCheck --stacktrace
 
@@ -69,9 +69,9 @@ jobs:
     name: Build debug
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
@@ -80,7 +80,7 @@ jobs:
         with:
           toolchain: stable
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -109,6 +109,6 @@ jobs:
             exit 1
           fi
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
       - name: Build with Gradle
         run: ./gradlew assembledebug --stacktrace

--- a/.github/workflows/android-debug-artifact-ondemand.yml
+++ b/.github/workflows/android-debug-artifact-ondemand.yml
@@ -12,13 +12,13 @@ jobs:
     if: github.event.comment.body == 'Build test apk' && (github.actor == 'VishalNehra' || github.actor == 'TranceLove' || github.actor == 'EmmanuelMess' || github.actor == 'VishnuSanal')
     steps:
       - name: Acknowledge the request with thumbs up reaction
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: '+1'
       - name: Github API Request
         id: request
-        uses: octokit/request-action@v2.0.2
+        uses: octokit/request-action@v3
         with:
           route: ${{ github.event.issue.pull_request.url }}
         env:
@@ -30,18 +30,18 @@ jobs:
           echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
           echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
       - name: Checkout PR Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
           ref: ${{fromJson(steps.request.outputs.data).head.ref}}
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
       - name: Set up NDK
-        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
+        uses: nttld/setup-ndk@v1
         with:
           ndk-version: r28c
           link-to-sdk: true
@@ -51,7 +51,7 @@ jobs:
         with:
           toolchain: stable
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -80,18 +80,18 @@ jobs:
             exit 1
           fi
       - name: Build with Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v6
         with:
           arguments: assembleDebug --stacktrace
       - name: Upload fdroid artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         id: artifact-upload-fdroid
         with:
           name: Amaze-Fdroid-debug
           path: app/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk
           if-no-files-found: error
       - name: Upload play artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         id: artifact-upload-play
         with:
           name: Amaze-Play-debug
@@ -105,7 +105,7 @@ jobs:
           echo "PR_Number: $PR_NUMBER"
           echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_OUTPUT"
       - name: Notify the user with a comment once the APK is uploaded
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ steps.find-pr-id.outputs.PR_NUMBER }}
           body: |

--- a/.github/workflows/android-debug-artifact-release.yml
+++ b/.github/workflows/android-debug-artifact-release.yml
@@ -8,14 +8,14 @@ jobs:
   apk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
       - name: Set up NDK
-        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
+        uses: nttld/setup-ndk@v1
         with:
           ndk-version: r28c
           link-to-sdk: true
@@ -25,7 +25,7 @@ jobs:
         with:
           toolchain: stable
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -54,16 +54,16 @@ jobs:
             exit 1
           fi
       - name: Build with Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v6
         with:
           arguments: assembleDebug
       - name: Upload fdroid artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Amaze-Fdroid-debug
           path: app/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk
       - name: Upload play artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Amaze-Play-debug
           path: app/build/outputs/apk/play/debug/app-play-debug.apk

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -16,21 +16,21 @@ jobs:
     name: Check spotless
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
       - name: Set up NDK
         id: setup-ndk
-        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
+        uses: nttld/setup-ndk@v1
         with:
           ndk-version: r28c
           link-to-sdk: true
           local-cache: true
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
       - name: Check formatting using spotless
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
@@ -40,9 +40,9 @@ jobs:
     name: Build debug and run Jacoco tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
@@ -51,7 +51,7 @@ jobs:
         with:
           toolchain: stable
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -80,7 +80,7 @@ jobs:
             exit 1
           fi
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
       - name: Build with Gradle
         run: ./gradlew assembledebug --stacktrace
       - name: Run test cases

--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -16,20 +16,20 @@ jobs:
     name: Check spotless
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
       - name: Set up NDK
-        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
+        uses: nttld/setup-ndk@v1
         with:
           ndk-version: r28c
           link-to-sdk: true
           local-cache: true
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
       - name: Check formatting using spotless
         run: ./gradlew spotlessCheck
 
@@ -37,11 +37,11 @@ jobs:
     name: Build debug, Jacoco test and publish to codacy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
@@ -50,7 +50,7 @@ jobs:
         with:
           toolchain: stable
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -79,7 +79,7 @@ jobs:
             exit 1
           fi
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
       - name: Build with Gradle
         run: ./gradlew assembledebug
       - name: Run test cases
@@ -107,9 +107,9 @@ jobs:
         api-level: [ 21, 28 ]
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
@@ -118,7 +118,7 @@ jobs:
         with:
           toolchain: stable
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -152,7 +152,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
       - name: AVD cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: avd-cache
         with:
           path: |

--- a/.github/workflows/fastlane-pr.yml
+++ b/.github/workflows/fastlane-pr.yml
@@ -13,7 +13,7 @@ jobs:
     # required to run on Linux because this is a docker container action
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ashutoshgngwr/validate-fastlane-supply-metadata@v2
         with:
           fastlaneDir: ./fastlane/metadata/android # optional


### PR DESCRIPTION
<!-- 
Read this first:
To open a pull request read this file,
uncomment the corresponding lines and 
complete them.
-->

## Description

#### Issue tracker   
<!-- Fixes will automatically close the related issue -->
<!-- Fixes # -->
<!-- Addresses won't automatically close the related issue -->
<!-- Addresses # -->

Node20 will reach end-of-life (EOL) in April of 2026.

As a result we have started the deprecation process of Node20 for GitHub Actions.

We plan to migrate all actions to run on Node24 in the fall of 2026.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/


#### Automatic tests
<!-- remember to do manual testing when making UI changes! -->
- [ ] Added test cases
  
#### Manual tests
- [x] Done  
  
<!-- If yes, -->
<!-- 
- Device:
- OS:
-->

#### Build tasks success  
<!-- run these! -->
Successfully running following tasks on local:
- [x] `./gradlew assembledebug`
- [x] `./gradlew spotlessCheck`

<!-- If there are related PRs please add them here -->
<!--
#### Related PR  
Related to PR #
-->
