### PR TITLE
Keep SMB rename verification off the UI thread

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/MainActivityHelper.java
@@ -388,7 +388,9 @@ public class MainActivityHelper {
                    * DocumentFile.renameTo() may return false even when rename is successful. Hence we need an extra check
                    * instead of merely looking at the return value
                    */
-                  if (b || newFile.exists(context)) {
+                  if (b
+                      || ((newFile.isDocumentFile() || newFile.isOtgFile())
+                          && newFile.exists(context))) {
                     Intent intent = new Intent(MainActivity.KEY_INTENT_LOAD_LIST);
 
                     intent.putExtra(


### PR DESCRIPTION
Problem:
The rename completion path in `MainActivityHelper` may call `newFile.exists(context)` on the UI thread after a rename attempt. For SMB targets that falls into `HybridFile.exists()` and performs synchronous `SmbFile.exists()` network I/O on the main thread.

Root cause:
The post-rename existence probe was added as a SAF workaround because `DocumentFile.renameTo()` can report false even when the rename succeeds, but the fallback was applied uniformly to all backends.

Fix:
Limit the post-rename `exists(context)` verification to SAF-backed targets (`DOCUMENT_FILE` and `OTG`) and skip that UI-thread probe for SMB and other non-SAF modes.

Closes #4610
